### PR TITLE
Add an option to mute Strava activity on update

### DIFF
--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -645,7 +645,7 @@ class Client(object):
             params['device_name'] = device_name
         
         if hide_from_home is not None:
-            params['hide_from_home'] = hide_from_home
+            params['hide_from_home'] = int(hide_from_home)
 
         raw_activity = self.protocol.put('/activities/{activity_id}', activity_id=activity_id, **params)
 

--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -588,7 +588,7 @@ class Client(object):
 
     def update_activity(self, activity_id, name=None, activity_type=None,
                         private=None, commute=None, trainer=None, gear_id=None,
-                        description=None,device_name=None):
+                        description=None, device_name=None, hide_from_home=None):
         """
         Updates the properties of a specific activity.
 
@@ -609,6 +609,7 @@ class Client(object):
         :param gear_id: Alpha-numeric ID of gear (bike, shoes) used on this activity.
         :param description: Description for the activity.
         :param device_name: Device name for the activity
+        :param hide_from_home: Whether the activity is muted (hidden from Home and Club feeds).
 
         :return: The updated activity.
         :rtype: :class:`stravalib.model.Activity`
@@ -642,6 +643,9 @@ class Client(object):
             
         if device_name is not None:
             params['device_name'] = device_name
+        
+        if hide_from_home is not None:
+            params['hide_from_home'] = hide_from_home
 
         raw_activity = self.protocol.put('/activities/{activity_id}', activity_id=activity_id, **params)
 

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -868,6 +868,8 @@ class Activity(LoadableEntity):
     highlighted_kudosers = Attribute(bool, (DETAILED,))  #: (undocumented)
 
     laps = EntityCollection(ActivityLap, (SUMMARY, DETAILED))  #: :class:`list` of :class:`stravalib.model.ActivityLap` objects.
+    
+    hide_from_home = Attribute(bool, (SUMMARY, DETAILED)) #: (undocumented) Whether an activity is muted (hidden from Home and Club feeds).
 
     @property
     def comments(self):

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -869,7 +869,7 @@ class Activity(LoadableEntity):
 
     laps = EntityCollection(ActivityLap, (SUMMARY, DETAILED))  #: :class:`list` of :class:`stravalib.model.ActivityLap` objects.
     
-    hide_from_home = Attribute(bool, (SUMMARY, DETAILED)) #: (undocumented) Whether an activity is muted (hidden from Home and Club feeds).
+    hide_from_home = Attribute(bool, (SUMMARY, DETAILED)) #: Whether an activity is muted (hidden from Home and Club feeds).
 
     @property
     def comments(self):


### PR DESCRIPTION
Recently Strava has introduced an option to "mute" an activity (hide it from Home and Club feeds, but keep visible on athlete's profile). From inspecting the activity structure, this `bool` activity setting is called `hide_from_home`. It has been available to all Strava users since September but, unfortunately, has not yet been documented on Strava's API page.