### PR TITLE
FEAT: Cleanup make files and add docs autobuild

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -64,4 +64,4 @@ jobs:
 
       - name: Run tests with pytest
         run: |
-          pytest stravalib/tests/unit stravalib/tests/integration
+          make test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,34 @@
-docs: docs/*.rst docs/conf.py docs/Makefile stravalib/*.py  ## generate html docs
-	# -fMeET -o docs/api stravalib stravalib/tests/ stravalib/tests/unit stravalib/tests/functional # omit tests dir from build
-	$(MAKE) -C docs clean
-	$(MAKE) -C docs html
-	$(MAKE) -C docs linkcheck
+TESTDIR=tmp-test-dir-stravalib
+PYTEST_ARGS=stravalib/tests/unit stravalib/tests/integration
+
+## I still need to add code cov to this build
+help:
+	@echo "Commands:"
+	@echo ""
+	@echo "  install   install package in editable mode"
+	@echo "  test      run the test suite (including doctests) and report coverage"
+	@echo "  build     build source and wheel distributions"
+	@echo "  clean     clean up build and generated files"
+	@echo ""
+
+
+build:
+	python -m build .
+
+install:
+	python -m pip install --no-deps -e .
+
+test:
+	# Create tmp dir to ensure that tests are run on the installed version of stravalib
+	mkdir -p $(TESTDIR)
+	cd $(TESTDIR); 
+	pytest $(PYTEST_ARGS) $(PROJECT)
+	## cp $(TESTDIR)/.coverage* .
+	rm -r $(TESTDIR)
+
+## Clean up all unneeded files and directories and things that shouldn't be under version control
+clean:
+	find . -name "*.pyc" -exec rm -v {} \;
+	find . -name "*.orig" -exec rm -v {} \;
+	find . -name ".coverage.*" -exec rm -v {} \;
+	rm -rvf build dist MANIFEST *.egg-info __pycache__ .coverage .cache .pytest_cache $(PROJECT)/_version_generated.py

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help:
 
 
 build:
-	python -m build .
+	python -m build
 
 install:
 	python -m pip install --no-deps -e .

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Welcome to stravalib
 
-**NOTE: This library could really use someone to help with (or take over) maintenance. Please reach out to hans@xmpl.org if you are interested in taking project over.**
-
 The **stravalib** project aims to provide a simple API for interacting with Strava v3 web services, in particular
 abstracting the v3 REST API around a rich and easy-to-use object model and providing support for date/time/temporal attributes
 and quantities with units (using the [python units library](http://pypi.python.org/pypi/units)).
 
-See the [online documentation](http://pythonhosted.org/stravalib/) for more comprehensive documentation.
+See the [online documentation](https://stravalib.readthedocs.io/) for more comprehensive documentation.
 
 ## Dependencies
 
@@ -206,4 +204,4 @@ num_value = unithelper.miles(activity.distance).num
 
 ## Still reading?
 
-The [published sphinx documentation](http://pythonhosted.org/stravalib/) provides much more.
+The [published sphinx documentation](https://stravalib.readthedocs.io/) provides much more.

--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,10 @@
 # Change Log
 
 ## Unreleased
-<<<<<<< HEAD
-=======
+
 * Fix: add new attributes for bikes according to updates to Strava API to fix warning message (huaminghuangtw, #239)
 * Add an option to mute Strava activity on update (@ollyajoke, #227)
 * Update make to build and serve docs and also run current tests (@lwasser,#263)
->>>>>>> eb6787a (FIX: cleanup make and builds)
 * FIX: Minor bug in PyPI push and also streamlined action build (@lwasser, #265)
 * Fix get_athlete w new attrs for shoes given strava updates to API (@lwasser, #220)
 * Refactor deprecated unittest aliases for Python 3.11 compatibility (@tirkarthi, #223)

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,12 @@
 # Change Log
 
 ## Unreleased
+<<<<<<< HEAD
+=======
+* Fix: add new attributes for bikes according to updates to Strava API to fix warning message (huaminghuangtw, #239)
+* Add an option to mute Strava activity on update (@ollyajoke, #227)
+* Update make to build and serve docs and also run current tests (@lwasser,#263)
+>>>>>>> eb6787a (FIX: cleanup make and builds)
 * FIX: Minor bug in PyPI push and also streamlined action build (@lwasser, #265)
 * Fix get_athlete w new attrs for shoes given strava updates to API (@lwasser, #220)
 * Refactor deprecated unittest aliases for Python 3.11 compatibility (@tirkarthi, #223)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,10 +1,9 @@
 # Makefile for Sphinx documentation
-#
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-PAPER         =
+SPHINXAUTOGEN = sphinx-autogen
 BUILDDIR      = _build
 
 # User-friendly check for sphinx-build
@@ -13,166 +12,33 @@ $(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx in
 endif
 
 # Internal variables.
-PAPEROPT_a4     = -D latex_paper_size=a4
-PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
-# the i18n builder cannot share the environment and doctrees with the others
-I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees  $(SPHINXOPTS) .
 
-# for now removing some of these and just including
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+.PHONY: help clean html
+
+# This runs if you run make -C docs from the root dir
+# This has to go above help to work by default
+all: html
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  html       to make standalone HTML files"
-	@echo "  dirhtml    to make HTML files named index.html in directories"
-	@echo "  singlehtml to make a single large HTML file"
-	@echo "  pickle     to make pickle files"
-	@echo "  json       to make JSON files"
-	@echo "  htmlhelp   to make HTML files and a HTML help project"
-	@echo "  qthelp     to make HTML files and a qthelp project"
-	@echo "  devhelp    to make HTML files and a Devhelp project"
-	@echo "  epub       to make an epub"
-	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
-	@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
-	@echo "  latexpdfja to make LaTeX files and run them through platex/dvipdfmx"
-	@echo "  text       to make text files"
-	@echo "  man        to make manual pages"
-	@echo "  texinfo    to make Texinfo files"
-	@echo "  info       to make Texinfo files and run them through makeinfo"
-	@echo "  gettext    to make PO message catalogs"
-	@echo "  changes    to make an overview of all changed/added/deprecated items"
-	@echo "  xml        to make Docutils-native XML files"
-	@echo "  pseudoxml  to make pseudoxml-XML files for display purposes"
-	@echo "  linkcheck  to check all external links for integrity"
-	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
-
+	@echo "  all        generate the complete documentation api and regular"
+	@echo "  html       make only the HTML files from the existing rst sources"
+	@echo "  clean      clean all local doc directories out"
+	@echo "  serve      serve the docs locally using sphinx autobuild"
+	
+# Run: make -C docs clean 
 clean:
-	rm -rf $(BUILDDIR)/*
+	rm -rf $(BUILDDIR)/html/*
+	rm -rf $(BUILDDIR)/doctrees
+	rm -rf .ipynb_checkpoints
 
-html:
+html: 
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-dirhtml:
-	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
-	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
-
-singlehtml:
-	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
-	@echo
-	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
-
-pickle:
-	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
-	@echo
-	@echo "Build finished; now you can process the pickle files."
-
-json:
-	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
-	@echo
-	@echo "Build finished; now you can process the JSON files."
-
-htmlhelp:
-	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
-	@echo
-	@echo "Build finished; now you can run HTML Help Workshop with the" \
-	      ".hhp project file in $(BUILDDIR)/htmlhelp."
-
-qthelp:
-	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
-	@echo
-	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
-	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/stravalib.qhcp"
-	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/stravalib.qhc"
-
-devhelp:
-	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
-	@echo
-	@echo "Build finished."
-	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/stravalib"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/stravalib"
-	@echo "# devhelp"
-
-epub:
-	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
-	@echo
-	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
-
-latex:
-	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
-	@echo
-	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
-	@echo "Run \`make' in that directory to run these through (pdf)latex" \
-	      "(use \`make latexpdf' here to do that automatically)."
-
-latexpdf:
-	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
-	@echo "Running LaTeX files through pdflatex..."
-	$(MAKE) -C $(BUILDDIR)/latex all-pdf
-	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
-
-latexpdfja:
-	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
-	@echo "Running LaTeX files through platex and dvipdfmx..."
-	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
-	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
-
-text:
-	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
-	@echo
-	@echo "Build finished. The text files are in $(BUILDDIR)/text."
-
-man:
-	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
-	@echo
-	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
-
-texinfo:
-	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
-	@echo
-	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
-	@echo "Run \`make' in that directory to run these through makeinfo" \
-	      "(use \`make info' here to do that automatically)."
-
-info:
-	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
-	@echo "Running Texinfo files through makeinfo..."
-	make -C $(BUILDDIR)/texinfo info
-	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
-
-gettext:
-	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
-	@echo
-	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
-
-changes:
-	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
-	@echo
-	@echo "The overview file is in $(BUILDDIR)/changes."
-
-linkcheck:
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
-	@echo
-	@echo "Link check complete; look for any errors in the above output " \
-	      "or in $(BUILDDIR)/linkcheck/output.txt."
-
-doctest:
-	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
-	@echo "Testing of doctests in the sources finished, look at the " \
-	      "results in $(BUILDDIR)/doctest/output.txt."
-
-xml:
-	$(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml
-	@echo
-	@echo "Build finished. The XML files are in $(BUILDDIR)/xml."
-
-pseudoxml:
-	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
-	@echo
-	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
+## Serve live docs in a browser
+serve:
+	pwd
+	sphinx-autobuild ../docs _build/html

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ responses
 # For docs build
 sphinx_copybutton
 pydata_sphinx_theme
+sphinx-autobuild


### PR DESCRIPTION
closes #261 

So this is an update to the make build that 

1. cleans up the make builds as they were a bit messy especially the docs one
2. adds  sphinx autobuild which is really nice for editing docs as it allows you to run the docs live as you edit them and view your updates in realtime in the browser. this saves a ton of time. 
3. Adds a clean step to clean out files in your dir that are crteated via builds that you'd never want to be in version control 

What we don't get with make is the virtual enviornment setup which might make it easier for a new contributor BUT make does the job. 

Once this PR which is small and the other big one are merged I will submit a new pr to update the builds to call make to streamline everything. That way we have the commands to do things like run CI tests in only one place so if we add more CI rules we can just update the makefile and the entire build will update!

NOTE: right now i don't have make setup to build the local tests that require api authentication. but we can talk about that later. that is a bit more complex 

----
UPDATE: i just closed a really old PR to update the docs link in the readme. i just added it to this PR as it's a small fix. 
