### PR TITLE
FIX: pypi build with version & simplify build ✨ 

### DIFF
--- a/.github/workflows/push-pypi.yml
+++ b/.github/workflows/push-pypi.yml
@@ -1,4 +1,4 @@
-name: Publish to Test PyPI.org
+name: Publish to PyPI
 on:
   release:
     types: [published]
@@ -6,22 +6,33 @@ on:
     branches:
       - master
 jobs:
-  build:
+  build-publish:
     runs-on: ubuntu-latest
-    # Only publish from the origin repository, not forks
-    # if: github.repository_owner == 'stravalib'
+    # This action only needs to run in the base repository
+    if: github.repository_owner == 'stravalib'
     steps:
       - name: Checkout
         uses: actions/checkout@v3 
         with:
           # So scm can view previous commits
-          fetch-depth: 20
-        # Install requirements
-      - run: |
+          fetch-depth: 100
+
+      # Need the tags so that setuptools-scm can form a valid version number
+      - name: Fetch git tags
+        run: git fetch origin 'refs/tags/*:refs/tags/*'
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install requirements
+        run: |
           python -m pip install -r requirements-build.txt
           pip list
-      # Build package 
-      - run: |
+
+      - name: Build package
+        run: |
           python3 -m build
           echo ""
           echo "Generated files:"
@@ -30,17 +41,7 @@ jobs:
       - name: Check the archives
         run: twine check dist/*
 
-#############################################################################
-  # Publish built wheels and source archives to PyPI and test PyPI
-  publish:
-    runs-on: ubuntu-latest
-    needs: build
-    # Only publish from the origin repository, not forks
-    if: github.repository_owner == 'stravalib'
-
-    steps:
-
-      - name: Publish package to test PyPI
+      - name: Publish package on test PyPI on merge
         # Test push to test pypi on merge to master
         if: github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -53,7 +54,7 @@ jobs:
       
       - name: Publish package to PyPI
         # Only publish to real PyPI on release
-        if: success() && github.event_name == 'release'
+        if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## Unreleased
-
+* FIX: Minor bug in PyPI push and also streamlined action build (@lwasser, #265)
 * Fix get_athlete w new attrs for shoes given strava updates to API (@lwasser, #220)
 * Refactor deprecated unittest aliases for Python 3.11 compatibility (@tirkarthi, #223)
 * Patch: Update readme and fix broken links in docs (@lwasser, #229)


### PR DESCRIPTION
This PR:

Fixes the issue where it couldn't find the dist/ dir. essentially to build that way i'd need to upload the archive and then download it in the publish step. That just was getting a lot more complex than it needed to be. 

Thus i opted to simplify the build and just have it all run in one step with conditionals. it also should only run in the stravalib main repo so other contributors don't have to worry about it. 