### PR TITLE
Fix: model PR to use str instead of six.texttype

### DIFF
--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -232,7 +232,7 @@ class Bike(Gear):
     Represents an athlete's bike.
     """
     frame_type = Attribute(int, (DETAILED,))  #: (detailed-only) Type of bike frame.
-    nickname = Attribute(six.text_type, (DETAILED,))  #: Nickname for the bike.
+    nickname = Attribute(str, (DETAILED,))  #: Nickname for the bike.
     converted_distance = Attribute(float, (SUMMARY, DETAILED), units=uh.meters)  #: Distance on the bike (meters)
     retired = Attribute(bool, (SUMMARY, DETAILED))  #: Is the bike retired?
 


### PR DESCRIPTION
I should have caught this issue in the open PR - we just hadn't migrated away from 2.x at the time of this pr. 