### PR TITLE
Fix: Add readthedocs config file to ensure that stravalib is installed in the build using pip

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -34,5 +34,5 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install -r ./requirements.txt
-          python3 -m pip install -e .
-      - run: make docs -B
+          python3 -m pip install .
+      - run: make -C docs html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,13 @@
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+formats: all
+
+python:
+  version: 3.8
+  install:
+    - method: pip
+      path: .
+    - requirements: requirements.txt

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ See the [online documentation](https://stravalib.readthedocs.io/) to learn more.
 
 The package is available on PyPI to be installed using `easy_install` or `Or you can
 
-
 ## How to Contribute to Stravalib
 
 ### Get Started!
@@ -49,9 +48,10 @@ local filesystem::
 3. Set up your fork for local development
 -----------------------------------------
 The docs for this library are created using `sphinx`.
-To build the documentation, use the command::
+To build the html version of the documentation, use the 
+command:
 
-`$ make -C docs -B`
+`$ make -C docs html`
 
 ### Building from sources
 

--- a/README.md
+++ b/README.md
@@ -55,23 +55,17 @@ command:
 
 ### Building from sources
 
-To build the project from sources access the project root directory and run
+To build the project locally in editable mode,
+access the project root directory and run:
 
 ```bash
-shell$ python setup.py build
+$ pip install -e .
 ```
-Running
-
-```
-shell$ make install
-```
-
-will build and install *stravalib* in your *pip* package repository.
 
 To execute **unit - or integration tests** you will need to run
 
 ```bash
-shell$ make test
+$ make test
 ```
 
 ## Local Tests 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Welcome to stravalib
+![PyPI](https://img.shields.io/pypi/v/stravalib?style=plastic) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/stravalib?style=plastic) [![Documentation Status](https://readthedocs.org/projects/stravalib/badge/?version=latest)](https://stravalib.readthedocs.io/en/latest/?badge=latest)
 
 The **stravalib** Python package provides easy-to-use tools for accessing and 
 downloading Strava data from the Strava V3 web service. Stravalib provides an 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Unreleased
+* Fix: Add readthedocs config file to ensure build installs using pip (@lwasser, #270)
 
 ## v1.0.0
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Welcome to Stravalib!
 `Strava <https://www.strava.com>`_  API.
 
 This library is designed provide a simple and easy-to-use object model paradigm for interacting
-with the API, support modern versions of Python (2.7, 3.2+), and expose the full functionality of the REST API.
+with the API, support modern versions of Python (3.7+), and expose the full functionality of the REST API.
 
 **Why use stravalib?**  The Strava REST API is fairly straightforward.  The main reasons to use something like
 stravalib would be:


### PR DESCRIPTION
closes #270 

in part but i think we should talk this through in that issue just to ensure we are all on the same page. 

This PR just adds a yml file with instructs readthedocs to build our package using pip. i think that with pip, the version_generated file must get created as long as you have tags locally the version should work.  

It also adds 3 badges to the readme:
* docs build or pass from readthedocs. that will make it easier to identify when a  build goes wrong
* python versions that we support
* current release version on pypi
