### PR TITLE
ADD: code of conduct to repo and update contributing guide with current workflow

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement by emailing
+leah at pyopensci.org .
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,155 @@
+# How to Contribute to Stravalib
+
+**Attention:** This contributing guide provides a high-level overview for contributing 
+to `stravalib`. If you are interested in submitting a pr, be sure to read our
+[development guide](https://stravalib.readthedocs.io/contributing/development-guide.html). 
+
+**Thank you for considering contributing to stravalib!** 
+
+This is a community-driven project. It's people like you that make it useful and
+successful. These are some of the many ways to contribute:
+
+* Submit bug reports and feature requests
+* Write tutorials or examples
+* Fix typos and improve the documentation
+* Submit code fixes
+
+## Contribution ground rules
+
+The stravalib maintainers work on stravalib in their free time because 
+they love the package's contribution to the Python ecosystem. As such we
+value contributions but also value respectful interactions with stravalib users.  
+
+**Please be considerate and respectful of others** in all of your communications
+in this repository.
+Everyone must abide by our [Code of Conduct](https://www.github.com/stravalib/stravalib/CODE_OF_CONDUCT.md). Please
+read it carefully. Our goal is to maintain a diverse community of stravalib users and contributors that's pleasant for everyone.
+
+## How to start contributing to stravalib
+If you are thinking about submitting a change to stravalib, please start
+by [submitting an issue in our GitHub repository](https://www.github.com/stravalib/stravalib/issues/). 
+We will use that issue to communicate with you about
+
+1. Whether the change is in scope for the project
+2. Any issues that you need help with or clarification on. 
+
+We welcome changes to both documentation and code. 
+
+### Want to submit a pull request with changes to our code or documentation?
+
+We welcome changes to stravalib through pull requests. Before you submit a 
+pull request please be sure to:
+
+1. Read this document fully 
+2. Submit an issue about the change as discussed below and
+2. [Read our development guide](https://stravalib.readthedocs.io/contributing/development-guide.html)
+
+### How to report a bug in stravalib or typo in our documentation
+Found a bug? Or a typo in our documentation? We want to know about it!  
+To report a bug or a documentation issue, please submit an issue on GitHub. 
+
+If you are submitting a bug report, **please add as much 
+detail as you can about the bug**. Remember: the more information we have, the easier it 
+will be for us to solve your problem.
+
+### Documentation fixes 
+If you're browsing the documentation and notice a typo or something that could be
+improved, please let us know by creating an issue. We also welcome you to 
+submit a documentation fix directly to us using a pull request to our 
+repository.
+
+## An overview of our stravalib git / GitHub workflow 
+We follow the [git pull request workflow](http://www.asmeurer.com/git-workflow/) to
+make changes to our codebase.
+Every change made goes through a pull request, even our own, so that our
+[continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) services
+can check that the code is up to standards and passes all of our tests.
+
+This workflow allows our  *master* branch to always be stable.
+
+### General guidelines for pull requests (PRs):
+
+* **Open an issue first** describing what you want to do. If there is already an issue that matches your PR, leave a comment there instead to let us know what you plan to do. Be as specific as you can in the issue.
+* Each pull request should contain a **small** and logical collection of changes directly related to the issue that you opened.
+* Larger changes should be broken down into smaller components and integrated
+  separately.
+* Bug fixes should be submitted in separate PRs.
+* Describe what your pull request changes and *why* this is a good thing (or refer to the issue that you opened if it contains that information). Be as specific as you can.
+* Do not commit changes to files that are irrelevant to your feature or bugfix (eg: `.gitignore`, IDE project files, etc).
+* Write descriptive commit messages that describe what your change is. 
+* Be willing to accept feedback and to work on your code through a pull request. We don't want to break other users' code, so care must be taken not to introduce bugs.
+* Be aware that the pull request review process is not immediate. The time that it takes to review a pull request is generally proportional to the size of the pull request. Larger pull requests may take longer to review and merge.
+
+### Testing your code 
+Automated testing helps ensure that our code is as free of bugs as it can be.
+It also lets us know immediately if a change we make breaks any other part of the code.
+
+All of our test code and data are stored in the `tests` directory within the stravalib package directory.
+We use the [pytest](https://pytest.org/) framework to run the test suite.
+
+If you are submitting a code fix, and know how to write tests, please include tests for your code in your pr. This helps us ensure that your change doesn't break any of the existing functionality.
+Tests also help us be confident that we won't break your code in the future.
+
+If you're **new to testing**, see existing test files for examples of things to do.
+**Don't let the tests keep you from submitting your contribution!**
+If you're not sure how to do this or are having trouble, submit your pull 
+request anyway. We will help you create the tests and sort out any kind of problem during code review.
+
+You can learn more about our test suite in the development guide. However, 
+if you wish to run the test suite locally, you can use: 
+
+```bash 
+make test
+```
+
+```{warning}
+THIS SECTION WILL BE UPDATED ONCE WE ADD CODECOV TO THE BUILD!
+
+The coverage report will let you know which lines of code are touched by the tests.
+```
+
+### Documentation
+
+Our documentation is in the `doc` folder.
+We use [sphinx](http://www.sphinx-doc.org/) to build the web pages from 
+these sources. To build the HTML files:
+
+```bash
+make -C docs html
+```
+
+To serve documentation locally use: 
+
+```bash
+make -C docs serve
+```
+
+You can learn more about our documentation infrastructure in our 
+development guide. 
+
+
+### Code Review
+
+After you've submitted a pull request, you should expect to hear at least a comment
+within a couple of days.
+We may suggest some changes or improvements or alternatives.
+
+Some things that will increase the chance that your pull request is accepted quickly:
+
+* Write a good and detailed description of what the PR does.
+* Write tests for the code you wrote/modified.
+* Readable code is better than clever code (even with comments).
+* Write documentation for your code (docstrings) and leave comments explaining the
+  *reason* behind non-obvious things.
+* Include an example of new features in the gallery or tutorials.
+* Follow the [numpy guide](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt)
+  for documentation.
+* Run the automatic code formatter and style checks.
+
+Pull requests will automatically have tests run by GitHub Actions.
+This includes running both the unit tests as well as code linters.
+Github will show the status of these checks on the pull request.
+Try to get them all passing (green).
+If you have any trouble, leave a comment in the PR or
+[get in touch](#how-can-i-talk-to-you).
+

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Welcome to stravalib
-![PyPI](https://img.shields.io/pypi/v/stravalib?style=plastic) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/stravalib?style=plastic) [![Documentation Status](https://readthedocs.org/projects/stravalib/badge/?version=latest)](https://stravalib.readthedocs.io/en/latest/?badge=latest)
+[![DOI](https://zenodo.org/badge/8828908.svg)](https://zenodo.org/badge/latestdoi/8828908) 
+![PyPI](https://img.shields.io/pypi/v/stravalib?style=plastic) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/stravalib?style=plastic) [![Documentation Status](https://readthedocs.org/projects/stravalib/badge/?version=latest)](https://stravalib.readthedocs.io/en/latest/?badge=latest) ![Package Tests Status](https://github.com/stravalib/stravalib/actions/workflows/build-test.yml/badge.svg) ![PyPI - Downloads](https://img.shields.io/pypi/dm/stravalib?style=plastic)
+
+https://github.com/stravalib/stravalib/actions/workflows/build-test.yml/badge.svg
 
 The **stravalib** Python package provides easy-to-use tools for accessing and 
-downloading Strava data from the Strava V3 web service. Stravalib provides an 
-easy-to-use CLient class that supports:
+downloading Strava data from the Strava V3 web service. Stravalib provides a Client class that supports:
 * Authenticating with stravalib 
 * Accessing and downloading strava activity, club and profile data 
 * Making changes to account activities 
 
 It also provides support for working with date/time/temporal attributes
 and quantities through the [Python units library](http://pypi.python.org/pypi/units).
-
-See the [online documentation](https://stravalib.readthedocs.io/) to learn more.
 
 ## Dependencies
 
@@ -21,7 +21,9 @@ See the [online documentation](https://stravalib.readthedocs.io/) to learn more.
 
 ## Installation
 
-The package is available on PyPI to be installed using `easy_install` or `Or you can
+The package is available on PyPI to be installed using `easy_install` or `pip`:
+
+`pip install stravalib`
 
 ## How to Contribute to Stravalib
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Unreleased
+* Add: add code of conduct to the repo, update contributing guide + readme badges (@lwasser, #269, #274) 
 * Fix: deprecated set-output command in actions build (@yihong0618, #272)
 * Fix: Add readthedocs config file to ensure build installs using pip (@lwasser, #270)
 


### PR DESCRIPTION
closes #274, #269

Please see the open issue #274 for explanation. 
This pr:

- [x] Adds badges to the readme addressing #269 
- [x] Adds a code of conduct and uses the template from the open source contributors code of conduct 
- [x] It also creates an updated contributing guide.

In a separate PR i'll submit a new development guide (the file linked to in this pr). i'm just trying to keep my pr's a bit smaller as that pr was going to be 15 files with all of the changes! 