### PR TITLE
Add: codecov to build for test coverage

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -66,3 +66,7 @@ jobs:
       - name: Run tests with pytest
         run: |
           make test
+
+      - name: Upload coverage to Codecov
+        if: ${{ matrix.os == 'ubuntu-latest' &&  matrix.python-version == '3.9'}}
+        uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ test.ini
 stravalib/_version_generated.py
 #*~
 examples/strava-oauth/settings.cfg
+# Code cov
+.coverage
 
 # so people don't mistakenly delete and submit a pr with these
 stravalib/tests/test.ini-example

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test:
 	mkdir -p $(TESTDIR)
 	cd $(TESTDIR); 
 	pytest $(PYTEST_ARGS) $(PROJECT)
-	#rm -r $(TESTDIR)
+	rm -r $(TESTDIR)
 
 ## Clean up all unneeded files and directories and things that shouldn't be under version control
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TESTDIR=tmp-test-dir-stravalib
-PYTEST_ARGS=stravalib/tests/unit stravalib/tests/integration
+PYTEST_ARGS=--cov stravalib stravalib/tests/unit stravalib/tests/integration
 
 ## I still need to add code cov to this build
 help:
@@ -23,8 +23,7 @@ test:
 	mkdir -p $(TESTDIR)
 	cd $(TESTDIR); 
 	pytest $(PYTEST_ARGS) $(PROJECT)
-	## cp $(TESTDIR)/.coverage* .
-	rm -r $(TESTDIR)
+	#rm -r $(TESTDIR)
 
 ## Clean up all unneeded files and directories and things that shouldn't be under version control
 clean:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to stravalib
 [![DOI](https://zenodo.org/badge/8828908.svg)](https://zenodo.org/badge/latestdoi/8828908) 
-![PyPI](https://img.shields.io/pypi/v/stravalib?style=plastic) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/stravalib?style=plastic) [![Documentation Status](https://readthedocs.org/projects/stravalib/badge/?version=latest)](https://stravalib.readthedocs.io/en/latest/?badge=latest) ![Package Tests Status](https://github.com/stravalib/stravalib/actions/workflows/build-test.yml/badge.svg) ![PyPI - Downloads](https://img.shields.io/pypi/dm/stravalib?style=plastic) [![codecov](https://codecov.io/gh/stravalib/stravalib/branch/master/graph/badge.svg?token=ISITKKVF5Y)](https://codecov.io/gh/stravalib/stravalib)
+![PyPI](https://img.shields.io/pypi/v/stravalib?style=plastic) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/stravalib?style=plastic) [![Documentation Status](https://readthedocs.org/projects/stravalib/badge/?version=latest)](https://stravalib.readthedocs.io/en/latest/?badge=latest) ![Package Tests Status](https://github.com/stravalib/stravalib/actions/workflows/build-test.yml/badge.svg) ![PyPI - Downloads](https://img.shields.io/pypi/dm/stravalib?style=plastic) [![codecov](https://codecov.io/gh/stravalib/stravalib/branch/master/graph/badge.svg?token=sHbFJn7epy)](https://codecov.io/gh/stravalib/stravalib)
 
 https://github.com/stravalib/stravalib/actions/workflows/build-test.yml/badge.svg
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to stravalib
 [![DOI](https://zenodo.org/badge/8828908.svg)](https://zenodo.org/badge/latestdoi/8828908) 
-![PyPI](https://img.shields.io/pypi/v/stravalib?style=plastic) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/stravalib?style=plastic) [![Documentation Status](https://readthedocs.org/projects/stravalib/badge/?version=latest)](https://stravalib.readthedocs.io/en/latest/?badge=latest) ![Package Tests Status](https://github.com/stravalib/stravalib/actions/workflows/build-test.yml/badge.svg) ![PyPI - Downloads](https://img.shields.io/pypi/dm/stravalib?style=plastic)
+![PyPI](https://img.shields.io/pypi/v/stravalib?style=plastic) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/stravalib?style=plastic) [![Documentation Status](https://readthedocs.org/projects/stravalib/badge/?version=latest)](https://stravalib.readthedocs.io/en/latest/?badge=latest) ![Package Tests Status](https://github.com/stravalib/stravalib/actions/workflows/build-test.yml/badge.svg) ![PyPI - Downloads](https://img.shields.io/pypi/dm/stravalib?style=plastic) [![codecov](https://codecov.io/gh/stravalib/stravalib/branch/master/graph/badge.svg?token=ISITKKVF5Y)](https://codecov.io/gh/stravalib/stravalib)
 
 https://github.com/stravalib/stravalib/actions/workflows/build-test.yml/badge.svg
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * Add: add code of conduct to the repo, update contributing guide + readme badges (@lwasser, #269, #274) 
 * Fix: deprecated set-output command in actions build (@yihong0618, #272)
 * Fix: Add readthedocs config file to ensure build installs using pip (@lwasser, #270)
+* Add: code cov to test suite (@lwasser, #262)
 
 ## v1.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ pytz
 # Testing
 pytest
 responses
+# Code coverage
+pytest-cov
 
 # For docs build
 sphinx_copybutton


### PR DESCRIPTION
closes #262 

This pr adds the code cov integration needed to both push to code cov and get reporting in each PR. 

* you can see the integration in this PR but there's nothing for it to diff against until we merge to master and use it in another PR
* I updated the readme file with a coverage badge as well. 

