### PR TITLE
Fix: dont include tests in code cov results

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+branch = True
+omit =
+    */tests/*
+    */_version_generated.py


### PR DESCRIPTION
Its a bit annoying that that test files are in the code cov results when run locally. this just adds a config file to ignore them so results look like this:

```bash
---------- coverage: platform darwin, python 3.8.13-final-0 ----------
Name                         Stmts   Miss Branch BrPart  Cover
--------------------------------------------------------------
stravalib/__init__.py            2      0      0      0   100%
stravalib/_version.py            2      0      0      0   100%
stravalib/attributes.py        170     19     62     13    83%
stravalib/client.py            439    180    205     15    55%
stravalib/exc.py                34      3      0      0    91%
stravalib/model.py             709    126     78      2    76%
stravalib/protocol.py          130     39     48     15    69%
stravalib/unithelper.py         16      1      0      0    94%
stravalib/util/__init__.py       0      0      0      0   100%
stravalib/util/limiter.py      122     27     44      5    76%
--------------------------------------------------------------
TOTAL                         1624    395    437     50    70%
```

We can ignore any files that we want this way with this file. I am curious how this will impact codecov.io - this is a specific configuration for pytest-cov. but it may also be the same in the report it sends to codecov.io. we shall see!

i didn't update the changelog here as this seems like a tiny update that i should have added in the original pr #262 . 