### PR TITLE
Units2pint

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
 
     steps:
       - uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ pull request please be sure to:
 
 1. Read this document fully 
 2. Submit an issue about the change as discussed below and
-2. [Read our development guide](https://stravalib.readthedocs.io/contributing/development-guide.html)
+2. [Read our development guide](https://stravalib.readthedocs.io/en/latest/contributing/development-guide.html)
 
 ### How to report a bug in stravalib or typo in our documentation
 Found a bug? Or a typo in our documentation? We want to know about it!  
@@ -131,7 +131,7 @@ make -C docs serve
 ```
 
 You can learn more about our documentation infrastructure in our 
-[development guide](https://stravalib.readthedocs.io/contributing/development-guide.html).
+[development guide](https://stravalib.readthedocs.io/en/latest/contributing/development-guide.html).
 
 ### Code Review and issue response timeline 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,7 @@ ways that you can contribute to `stravalib`:
 * Fix typos and improve the documentation
 * Submit code fixes
 
-[Please read our
-development guide](https://stravalib.readthedocs.io/contributing/development-guide.html) 
+[Please read our development guide](https://stravalib.readthedocs.io/en/latest/contributing/development-guide.html) 
 if you are interested in submitting a pull request to suggest changes to 
 our code or documentation.
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ downloading Strava data from the Strava V3 web service. Stravalib provides a Cli
 * Making changes to account activities 
 
 It also provides support for working with date/time/temporal attributes
-and quantities through the [Python units library](http://pypi.python.org/pypi/units).
+and quantities through the [Python Pint library](https://pypi.org/project/Pint/).
 
 ## Dependencies
 
 * Python 3.7+
 * Setuptools for installing dependencies
-* Other Python libraries (installed automatically when using pip/easy_install): requests, pytz, units, arrow
+* Other Python libraries (installed automatically when using pip/easy_install): requests, pytz, pint, arrow
 
 ## Installation
 
@@ -111,7 +111,7 @@ authorize_url = client.authorization_url(client_id=1234, redirect_uri='http://lo
 # .....
 
 # Extract the code from your webapp response
-code = request.get('code') # or whatever your framework does
+code = requests.get('code') # or whatever your framework does
 token_response = client.exchange_code_for_token(client_id=1234, client_secret='asdf1234', code=code)
 access_token = token_response['access_token']
 refresh_token = token_response['refresh_token']
@@ -180,15 +180,14 @@ if 'altitude' in streams.keys():
 
 ### Working with Units
 
-stravalib uses the [python units library](https://pypi.python.org/pypi/units/) to facilitate working
-with the values in the API that have associated units (e.g. distance, speed).  You can use the units library
-directly
-stravalib.unithelper module for shortcuts
+stravalib uses the [python Pint library](https://pypi.org/project/Pint/) to facilitate working
+with the values in the API that have associated units (e.g. distance, speed).  You can use the pint library
+directly or through the `stravalib.unithelper` module for shortcuts
 
 ```python
 
 activity = client.get_activity(96089609)
-assert isinstance(activity.distance, units.quantity.Quantity)
+assert isinstance(activity.distance, unithelper.Quantity)
 print(activity.distance)
 # 22530.80 m
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and quantities through the [Python Pint library](https://pypi.org/project/Pint/)
 
 ## Dependencies
 
-* Python 3.7+
+* Python 3.8+
 * Setuptools for installing dependencies
 * Other Python libraries (installed automatically when using pip/easy_install): requests, pytz, pint, arrow
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 * Fix: deprecated set-output command in actions build (@yihong0618, #272)
 * Fix: Add readthedocs config file to ensure build installs using pip (@lwasser, #270)
 * Add: pull request templates for regular pr and release (@lwasser, #294)
+* Add: Replace `units` dependency by `pint` (@jsamoocha, #281)
 
 ## v1.0.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,9 @@
 * Fix: deprecated set-output command in actions build (@yihong0618, #272)
 * Fix: Add readthedocs config file to ensure build installs using pip (@lwasser, #270)
 * Add: pull request templates for regular pr and release (@lwasser, #294)
-* Add: Replace `units` dependency by `pint` (@jsamoocha, #281)
+* Change: Replace `units` dependency by `pint` (@jsamoocha, #281)
+* Remove: Support for python 3.7
+* Add: Support for python 3.11
 
 ## v1.0.0
 

--- a/docs/get-started/overview.rst
+++ b/docs/get-started/overview.rst
@@ -99,7 +99,7 @@ what people would actually want to see (e.g. meters-per-second instead of
 kilometers-per-hour or miles-per-hour).
 
 To facilitate working with these quantities, stravalib makes use of the
-`units library <https://pypi.org/project/units/>`_.  You can simply cast the values string
+`pint library <https://pypi.org/project/Pint/>`_.  You can simply cast the values string
 to see a representation that includes the units::
 
    activity = client.get_activity(96089609)
@@ -116,7 +116,7 @@ library directly, stravalib provides a preconfigured set of common units to simp
    # 14.00 mi
 
 Of course, if you want to do something besides display those values, you'll likely
-want a number.  You can directly access the 'num' attribute of the :class:`units.quantity.Quantity` instance,
+want a number.  You can directly access the 'magnitude' attribute of the :class:`pint.Quantity` instance,
 or just cast to a numeric type (e.g. float).::
 
    activity = client.get_activity(96089609)

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,7 +71,7 @@ downloading Strava data from the Strava V3 web service. Stravalib provides a
 * Making changes to account activities 
 
 It also provides support for working with date/time/temporal attributes
-and quantities through the [Python units library](https://pypi.org/project/units/).
+and quantities through the [Python Pint library](https://pypi.org/project/Pint/).
 
 ## Why use stravalib?
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 arrow
 requests>=2.0,<3.0dev
-units
+pint
 pytz
 
 # Testing

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,10 +22,10 @@ classifiers =
     Topic :: Scientific/Engineering
     Topic :: Software Development :: Libraries
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 url = https://github.com/stravalib/stravalib
 project_urls =
     Documentation = https://stravalib.readthedocs.io
@@ -36,7 +36,7 @@ project_urls =
 [options]
 zip_safe = True
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     pint
     pytz

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ zip_safe = True
 include_package_data = True
 python_requires = >=3.7
 install_requires =
-    units
+    pint
     pytz
     arrow
     requests

--- a/stravalib/attributes.py
+++ b/stravalib/attributes.py
@@ -7,16 +7,16 @@ The types system provides a mechanism for serializing/un the data to/from JSON
 structures and for capturing additional information about the model attributes.
 """
 import logging
-from datetime import datetime, timedelta, tzinfo, date
 from collections import namedtuple
-from weakref import WeakKeyDictionary, WeakValueDictionary
+from datetime import datetime, timedelta, tzinfo, date
+from weakref import WeakKeyDictionary
 
 import arrow
 import pytz
 from pytz.exceptions import UnknownTimeZoneError
-from units.quantity import Quantity
 
 import stravalib.model
+from stravalib.unithelper import is_quantity_type
 
 # Depending on the type of request, objects will be returned in meta,  summary or detailed representations. The
 # representation of the returned object is indicated by the resource_state attribute.
@@ -74,7 +74,7 @@ class Attribute(object):
         (By default this will just return the underlying object; subclasses
         can override for specific behaviors -- e.g. date formatting.)
         """
-        if isinstance(v, Quantity):
+        if is_quantity_type(v):
             return v.num
         else:
             return v
@@ -89,7 +89,7 @@ class Attribute(object):
         """
         if self.units:
             # Note that we don't want to cast to type in this case!
-            if not isinstance(v, Quantity):
+            if not is_quantity_type(v):
                 v = self.units(v)
         elif not isinstance(v, self.type):
             v = self.type(v)

--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -4,24 +4,23 @@ Client
 Provides the main interface classes for the Strava version 3 REST API.
 """
 
+import calendar
+import collections
 import functools
 import logging
 import time
-import collections
-import calendar
-from io import BytesIO
 from datetime import datetime, timedelta
+from io import BytesIO
 
 import arrow
 import pytz
 
-from units.quantity import Quantity
-
-from stravalib.exc import warn_param_deprecation, warn_param_unofficial
 from stravalib import model, exc
+from stravalib import unithelper
+from stravalib.exc import warn_param_deprecation, warn_param_unofficial
 from stravalib.protocol import ApiV3
 from stravalib.util import limiter
-from stravalib import unithelper
+from stravalib.unithelper import is_quantity_type
 
 
 class Client(object):
@@ -583,13 +582,13 @@ class Client(object):
         :param description: The description for the activity.
         :type description: str
 
-        :param distance: The distance in meters (float) or a :class:`units.quantity.Quantity` instance.
-        :type distance: :class:`units.quantity.Quantity` or float (meters)
+        :param distance: The distance in meters (float) or a :class:`pint.Quantity` instance.
+        :type distance: :class:`pint.Quantity` or float (meters)
         """
         if isinstance(elapsed_time, timedelta):
             elapsed_time = elapsed_time.seconds
 
-        if isinstance(distance, Quantity):
+        if is_quantity_type(distance):
             distance = float(unithelper.meters(distance))
 
         if isinstance(start_date_local, datetime):

--- a/stravalib/exc.py
+++ b/stravalib/exc.py
@@ -113,3 +113,13 @@ def warn_param_unofficial(param_name: str):
         FutureWarning,
         stacklevel=3
     )
+
+
+def warn_units_deprecated():
+    warnings.warn(
+        'You are using a Quantity object or attributes from the units library, which is '
+        'deprecated. Support for these types will be removed in the future. Instead, '
+        'please use Quantity objects from the Pint package (https://pint.readthedocs.io).',
+        DeprecationWarning,
+        stacklevel=3
+    )

--- a/stravalib/tests/unit/test_model.py
+++ b/stravalib/tests/unit/test_model.py
@@ -1,8 +1,7 @@
-from units.quantity import Quantity
-
 from stravalib import model
 from stravalib import unithelper as uh
 from stravalib.tests import TestBase
+from stravalib.unithelper import Quantity
 
 
 class ModelTest(TestBase):
@@ -25,8 +24,8 @@ class ModelTest(TestBase):
 
         a.max_speed = 1000  # m/s
         a.average_speed = 1000  # m/s
-        self.assertEqual(3600.0, float(uh.kph(a.max_speed)))
-        self.assertEqual(3600.0, float(uh.kph(a.average_speed)))
+        self.assertAlmostEqual(3600.0, float(uh.kph(a.max_speed)))
+        self.assertAlmostEqual(3600.0, float(uh.kph(a.average_speed)))
 
         a.max_speed = uh.mph(1.0)
         # print repr(a.max_speed)

--- a/stravalib/tests/unit/test_unithelper.py
+++ b/stravalib/tests/unit/test_unithelper.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+
+import pint
+import pytest
+from pint import Unit
+
+from stravalib import unithelper as uh
+from stravalib.unithelper import UnitsQuantity
+
+
+@dataclass
+class UnitsLikeQuantity(UnitsQuantity):
+    num: float
+    unit: str
+
+
+@pytest.mark.parametrize(
+    'from_unit,to_unit,expected_magnitude,expected_unit',
+    (
+        (None, 'meter', 1, 'meter'),
+        ('meter', 'meter', 1, 'meter'),
+        ('km', 'meter', 1000, 'meter'),
+        ('m/s', 'kph', 3.6, 'kilometer / hour')
+    )
+)
+class TestUnitConversion:
+    def test_conversion_legacy(self, from_unit, to_unit, expected_magnitude, expected_unit):
+        quantity = UnitsLikeQuantity(1, from_unit) if from_unit else 1
+        with pytest.warns(DeprecationWarning):
+            converted_quantity = getattr(uh, to_unit)(quantity)
+            assert converted_quantity.num == pytest.approx(expected_magnitude, .01)
+            assert str(converted_quantity.unit) == expected_unit
+
+    def test_conversion(self, from_unit, to_unit, expected_magnitude, expected_unit):
+        quantity = 1 * Unit(from_unit) if from_unit else 1
+        converted_quantity = getattr(uh, to_unit)(quantity)
+        assert converted_quantity.magnitude == pytest.approx(expected_magnitude, .01)
+        assert str(converted_quantity.units) == expected_unit
+
+
+@pytest.mark.parametrize(
+    'obj,expected_result,expected_warning',
+    (
+        (pint.Quantity('m'), True, None),
+        (uh.Quantity(pint.Quantity('m')), True, None),
+        (uh.meters(1), True, None),
+        (UnitsLikeQuantity(1, 'meter'), True, DeprecationWarning),
+        (42, False, None)
+    )
+)
+def test_is_quantity_type(obj, expected_result, expected_warning):
+    if expected_warning:
+        with pytest.warns(expected_warning):
+            assert uh.is_quantity_type(obj) == expected_result
+    else:
+        assert uh.is_quantity_type(obj) == expected_result

--- a/stravalib/unithelper.py
+++ b/stravalib/unithelper.py
@@ -2,28 +2,102 @@
 Unit Helper
 ==============
 Helpers for converting Strava's units to something more practical.
-
-These are really just thin wrappers to the brilliant 'units' python library.
 """
-from units import unit
-import units.predefined
+from numbers import Number
+from typing import Protocol, Union, runtime_checkable, Any
 
-# Setup the units we will use in this module.
-units.predefined.define_units()
+import pint
 
-meter = meters = unit('m')
-second = seconds = unit('s')
-hour = hours = unit('h')
-foot = feet = unit('ft')
-mile = miles = unit('mi')
-kilometer = kilometers = unit('km')
+from stravalib.exc import warn_units_deprecated
 
-meters_per_second = meter / second
-miles_per_hour = mph = mile / hour
-kilometers_per_hour = kph = kilometer / hour
 
-kilogram = kilograms = kg = kgs = unit('kg')
-pound = pounds = lb = lbs = unit('lb')
+@runtime_checkable
+class UnitsQuantity(Protocol):
+    """
+    A type that represents the (deprecated) `units` Quantity. The `unit`
+    attribute in the units library consists of other classes, so this
+    representation may not be 100% backward compatible!
+    """
+    num: float
+    unit: str
+
+
+class Quantity:
+    """
+    Wraps `pint.Quantity`. Subclassing didn't work because pint has some heavily
+    customized attribute lookup
+    """
+
+    def __init__(self, q: pint.Quantity):
+        self.q = q
+
+    @property
+    def num(self):
+        warn_units_deprecated()
+        return self.q.magnitude
+
+    @property
+    def unit(self):
+        warn_units_deprecated()
+        return str(self.q.units)
+
+    def __int__(self):
+        return int(self.q.magnitude)
+
+    def __float__(self):
+        return float(self.q.magnitude)
+
+    def __getattr__(self, item):
+        return getattr(self.q, item)
+
+    def __str__(self):
+        return str(self.q)
+
+    def __repr__(self):
+        return repr(self.q)
+
+
+class UnitConverter:
+    def __init__(self, unit: str):
+        self.unit = pint.Unit(unit)
+
+    def __call__(self, q: Union[Number, pint.Quantity, UnitsQuantity]):
+        if isinstance(q, Number):
+            # provided quantity is unitless, so mimick legacy `units` behavior:
+            converted_q = self.unit * q
+        else:
+            try:
+                converted_q = q.to(self.unit)
+            except AttributeError:
+                # unexpected type of quantity, maybe it's a legacy `units` Quantity
+                warn_units_deprecated()
+                converted_q = (pint.Unit(str(q.unit)) * q.num).to(self.unit)
+
+        return Quantity(converted_q)  # adds legacy `units` behavior
+
+
+def is_quantity_type(obj: Any):
+    if isinstance(obj, (pint.Quantity, Quantity)):
+        return True
+    elif isinstance(obj, UnitsQuantity):  # check using Duck Typing
+        warn_units_deprecated()
+        return True
+    else:
+        return False
+
+
+meter = meters = UnitConverter('m')
+second = seconds = UnitConverter('s')
+hour = hours = UnitConverter('h')
+foot = feet = UnitConverter('ft')
+mile = miles = UnitConverter('mi')
+kilometer = kilometers = UnitConverter('km')
+
+meters_per_second = UnitConverter('m/s')
+miles_per_hour = mph = UnitConverter('mi/h')
+kilometers_per_hour = kph = UnitConverter('km/h')
+kilogram = kilograms = kg = kgs = UnitConverter('kg')
+pound = pounds = lb = lbs = UnitConverter('lb')
 
 
 def c2f(celsius):


### PR DESCRIPTION
closes #281

## Description

Replaces the dependency on `units` with the `pint` library since the former is no longer maintained. Adds helper classes and functions to maintain backward compatibility. Unless client code uses internals of the `units.Quantity` type, the result of this change should be compatible with existing code.


## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [x] Other (please describe)

The `units` package is no longer maintained and may lead to dependency resolution errors (e.g., in pipenv 2022.11.30).

## Does your PR include tests

- [x] Yes
- [ ] No, i'd like some help with tests
- [ ] This change doesn't require tests

## Do all of the CI tests run successfully on this pr?

- [ ] Check this when your PR has a green check. 
