### PR TITLE
Prevents pre-commit CI from failing because of missing config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,4 @@
+# Placeholder for pre-commit config that will be added later.
+# Pre-commit CI needs this file to exist and will fail otherwise.
+
+repos: []


### PR DESCRIPTION
closes #310 

## Description

This simply adds an empty pre-commit config file to prevent CI from failing.


## Type of change

Select the statement best describes this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [x] This change doesn't require tests

## Do all of the CI tests run successfully on this pr?

- [ ] Check this when your PR has a green check. 
