### PR TITLE
Nested model attributes

### DIFF
--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -1903,9 +1903,15 @@ class BatchedResultsIterator(object):
 
         entities = []
         for raw in raw_results:
-            entities.append(
-                self.entity.deserialize(raw, bind_client=self.bind_client)
-            )
+            try:
+                new_entity = self.entity.parse_obj(raw)
+                # TODO: try adding bind_client to entity
+            except AttributeError:
+                # entity doesn't have a parse_obj() method, so must be of a legacy type
+                new_entity = self.entity.deserialize(
+                    raw, bind_client=self.bind_client
+                )
+            entities.append(new_entity)
 
         self._buffer = collections.deque(entities)
 

--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -442,6 +442,9 @@ class Client(object):
 
         https://developers.strava.com/docs/reference/#api-Athletes-getStats
 
+        Note that this will return the stats for _public_ activities only,
+        regardless of the scopes of the current access token.
+
         :return: A model containing the Stats
         :rtype: :py:class:`stravalib.model.AthleteStats`
         """

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -6,9 +6,9 @@ Entity classes for representing the various Strava datatypes.
 import abc
 import logging
 from collections.abc import Sequence
-from typing import Dict
+from typing import Dict, List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 from stravalib import exc
 from stravalib import unithelper as uh
@@ -305,11 +305,31 @@ class AthleteStats(
         "biggest_climb_elevation_gain": "meters",
     }
 
+    @validator(
+        "recent_ride_totals",
+        "recent_run_totals",
+        "recent_swim_totals",
+        "ytd_ride_totals",
+        "ytd_run_totals",
+        "ytd_swim_totals",
+        "all_ride_totals",
+        "all_run_totals",
+        "all_swim_totals",
+    )
+    def to_extended_totals(cls, raw_totals: Dict):
+        return ActivityTotals.parse_obj(raw_totals)
+
 
 class Athlete(
     DetailedAthlete, DeprecatedSerializableMixin, BackwardCompatibilityMixin
 ):
-    pass
+    @validator("clubs")
+    def to_extended_clubs(cls, raw_clubs: List[Dict]):
+        return [Club.parse_obj(c) for c in raw_clubs]
+
+    @validator("bikes", "shoes")
+    def to_extended_gear(cls, raw_gear: List[Dict]):
+        return [Gear.parse_obj(g) for g in raw_gear]
 
 
 class ActivityComment(LoadableEntity):

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -303,6 +303,11 @@ class ActivityTotals(
 class AthleteStats(
     ActivityStats, DeprecatedSerializableMixin, BackwardCompatibilityMixin
 ):
+    """
+    Rolled-up totals for rides, runs and swims, as shown in an athlete's public
+    profile. Non-public activities are not counted for these totals.
+    """
+
     _unit_registry = {
         "biggest_ride_distance": "meters",
         "biggest_climb_elevation_gain": "meters",

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -30,6 +30,7 @@ from stravalib.field_conversions import enum_values, time_interval
 from stravalib.strava_model import (
     ActivityStats,
     ActivityTotal,
+    Comment,
     DetailedAthlete,
     DetailedClub,
     DetailedGear,
@@ -332,19 +333,10 @@ class Athlete(
         return [Gear.parse_obj(g) for g in raw_gear]
 
 
-class ActivityComment(LoadableEntity):
-    """
-    Comments attached to an activity.
-    """
-
-    activity_id = Attribute(int, (META, SUMMARY, DETAILED))  #: ID of activity
-    text = Attribute(str, (META, SUMMARY, DETAILED))  #: Text of comment
-    created_at = TimestampAttribute(
-        (SUMMARY, DETAILED)
-    )  #: :class:`datetime.datetime` when was coment created
-    athlete = EntityAttribute(
-        Athlete, (SUMMARY, DETAILED)
-    )  #: Associated :class:`stravalib.model.Athlete` (summary-level representation)
+class ActivityComment(Comment):
+    @validator("athlete")
+    def to_extended_athlete(cls, raw_athlete: Dict):
+        return Athlete.parse_obj(raw_athlete)
 
 
 class ActivityPhotoPrimary(LoadableEntity):

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -34,6 +34,8 @@ from stravalib.strava_model import (
     DetailedAthlete,
     DetailedClub,
     DetailedGear,
+    PhotosSummary,
+    Primary,
 )
 from stravalib.unithelper import UnitConverter
 
@@ -339,42 +341,24 @@ class ActivityComment(Comment):
         return Athlete.parse_obj(raw_athlete)
 
 
-class ActivityPhotoPrimary(LoadableEntity):
-    """
-    A primary photo attached to an activity (different structure from full photo record)
-    """
-
-    id = Attribute(
-        int, (META, SUMMARY, DETAILED)
-    )  #: ID of photo, if external.
-    unique_id = Attribute(
-        str, (META, SUMMARY, DETAILED)
-    )  #: ID of photo, if internal.
-    urls = Attribute(dict, (META, SUMMARY, DETAILED))
-    source = Attribute(
-        int, (META, SUMMARY, DETAILED)
-    )  #: 1=internal, 2=instagram
-    use_primary_photo = Attribute(
-        bool, (META, SUMMARY, DETAILED)
-    )  #: (undocumented)
+class ActivityPhotoPrimary(Primary):
+    pass
 
 
-class ActivityPhotoMeta(BaseEntity):
+class ActivityPhotoMeta(PhotosSummary):
     """
     The photos structure returned with the activity, not to be confused with the full loaded photos for an activity.
     """
 
-    count = Attribute(int, (META, SUMMARY, DETAILED))
-    primary = EntityAttribute(ActivityPhotoPrimary, (META, SUMMARY, DETAILED))
-    use_primary_photo = Attribute(bool, (META, SUMMARY, DETAILED))
-
-    def __repr__(self):
-        return "<{0} count={1}>".format(self.__class__.__name__, self.count)
+    @validator("primary")
+    def to_extended_primary(cls, raw_primary: Dict):
+        return ActivityPhotoPrimary.parse_obj(raw_primary)
 
 
 class ActivityPhoto(LoadableEntity):
     """
     A full photo record attached to an activity.
+    TODO: this entity is entirely undocumented by Strava and there is no official endpoint to retrieve it
     """
 
     athlete_id = Attribute(int, (META, SUMMARY, DETAILED))  #: ID of athlete

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -419,45 +419,12 @@ class ActivityPhoto(LoadableEntity):
         )
 
 
-class ActivityKudos(LoadableEntity):
+class ActivityKudos(Athlete):
     """
     Activity kudos are a subset of athlete properties.
     """
 
-    firstname = Attribute(str, (SUMMARY, DETAILED))  #: Athlete's first name.
-    lastname = Attribute(str, (SUMMARY, DETAILED))  #: Athlete's last name.
-    profile_medium = Attribute(
-        str, (SUMMARY, DETAILED)
-    )  #: URL to a 62x62 pixel profile picture
-    profile = Attribute(
-        str, (SUMMARY, DETAILED)
-    )  #: URL to a 124x124 pixel profile picture
-    city = Attribute(str, (SUMMARY, DETAILED))  #: Athlete's home city
-    state = Attribute(str, (SUMMARY, DETAILED))  #: Athlete's home state
-    country = Attribute(str, (SUMMARY, DETAILED))  #: Athlete's home country
-    sex = Attribute(
-        str, (SUMMARY, DETAILED)
-    )  #: Athlete's sex ('M', 'F' or null)
-    friend = Attribute(
-        str, (SUMMARY, DETAILED)
-    )  #: 'pending', 'accepted', 'blocked' or 'null' the authenticated athlete's following status of this athlete
-    follower = Attribute(
-        str, (SUMMARY, DETAILED)
-    )  #: 'pending', 'accepted', 'blocked' or 'null' this athlete's following status of the authenticated athlete
-    premium = Attribute(
-        bool, (SUMMARY, DETAILED)
-    )  #: Whether athlete is a premium member (true/false)
-
-    created_at = TimestampAttribute(
-        (SUMMARY, DETAILED)
-    )  #: :class:`datetime.datetime` when athlete record was created.
-    updated_at = TimestampAttribute(
-        (SUMMARY, DETAILED)
-    )  #: :class:`datetime.datetime` when athlete record was last updated.
-
-    approve_followers = Attribute(
-        bool, (SUMMARY, DETAILED)
-    )  #: Whether athlete has elected to approve followers
+    pass
 
 
 class ActivityLap(LoadableEntity):

--- a/stravalib/tests/auth_responder.py
+++ b/stravalib/tests/auth_responder.py
@@ -24,6 +24,7 @@ from urllib import parse as urlparse
 
 from stravalib import Client
 
+
 class StravaAuthHTTPServer(HTTPServer):
     def __init__(
         self,

--- a/stravalib/tests/integration/test_client.py
+++ b/stravalib/tests/integration/test_client.py
@@ -486,3 +486,14 @@ def test_get_activity_comments(mock_strava_api, client):
     )  # no idea what the markdown param is supposed to do
     assert len(comment_list) == 2
     assert comment_list[0].text == "foo"
+
+
+def test_get_activity_kudos(mock_strava_api, client):
+    mock_strava_api.get(
+        "/activities/{id}/kudos",
+        response_update={"lastname": "Doe"},
+        n_results=2,
+    )
+    kudoer_list = list(client.get_activity_kudos(42))
+    assert len(kudoer_list) == 2
+    assert kudoer_list[0].lastname == "Doe"

--- a/stravalib/tests/integration/test_client.py
+++ b/stravalib/tests/integration/test_client.py
@@ -473,3 +473,16 @@ def test_get_activities_paged(mock_strava_api, client):
     assert len(activity_list) == 500
     assert activity_list[0].id == 1
     assert activity_list[400].id == 3
+
+
+def test_get_activity_comments(mock_strava_api, client):
+    mock_strava_api.get(
+        "/activities/{id}/comments",
+        response_update={"text": "foo"},
+        n_results=2,
+    )
+    comment_list = list(
+        client.get_activity_comments(42)
+    )  # no idea what the markdown param is supposed to do
+    assert len(comment_list) == 2
+    assert comment_list[0].text == "foo"

--- a/stravalib/tests/unit/test_client_utils.py
+++ b/stravalib/tests/unit/test_client_utils.py
@@ -101,9 +101,9 @@ class TestClientUploadActivity(TestBase):
 
         """
 
-        with mock.patch("stravalib.protocol.ApiV3.post", return_value={}), open(
-            os.path.join(RESOURCES_DIR, "sample.tcx")
-        ) as fp:
+        with mock.patch(
+            "stravalib.protocol.ApiV3.post", return_value={}
+        ), open(os.path.join(RESOURCES_DIR, "sample.tcx")) as fp:
             # test activity_file with type TextIOWrapper
             uploader = self.client.upload_activity(fp, data_type="tcx")
             self.assertTrue(uploader.is_processing)
@@ -116,6 +116,8 @@ class TestClientUploadActivity(TestBase):
 
             # test activity_file with type bytes
             uploader = self.client.upload_activity(
-                fp.read().encode("utf-8"), data_type="tcx", activity_type="ride"
+                fp.read().encode("utf-8"),
+                data_type="tcx",
+                activity_type="ride",
             )
             self.assertTrue(uploader.is_processing)

--- a/stravalib/tests/unit/test_limiter.py
+++ b/stravalib/tests/unit/test_limiter.py
@@ -2,11 +2,11 @@ import arrow
 
 from stravalib.tests import TestBase
 from stravalib.util.limiter import (
-    get_rates_from_response_headers,
-    XRateLimitRule,
-    get_seconds_until_next_quarter,
-    get_seconds_until_next_day,
     SleepingRateLimitRule,
+    XRateLimitRule,
+    get_rates_from_response_headers,
+    get_seconds_until_next_day,
+    get_seconds_until_next_quarter,
 )
 
 test_response = {


### PR DESCRIPTION
Adds support for nested model attributes. This ensures that entities within entities (e.g., `ActivityTotals` as part of `AthleteStats`) are also of the correct extended types and will be backward-compatible.

In addition to previous work on this branch, this PR also replaces the following legacy entities:

- ActivityComment
- ActivityPhotoPrimary
- ActivityPhotoMeta
- ActivityKudos