### PR TITLE
Fix: Corrects attribute lookup for enum values

### DIFF
--- a/stravalib/field_conversions.py
+++ b/stravalib/field_conversions.py
@@ -36,6 +36,7 @@ def enum_value(v: Enum) -> Any:
 def enum_values(enums: Sequence[Enum]) -> List:
     # Pydantic (1.x) has config for using enum values, but unfortunately
     # it doesn't work for lists of enums.
+    # See https://github.com/pydantic/pydantic/issues/5005
     return [enum_value(e) for e in enums]
 
 

--- a/stravalib/tests/unit/test_model.py
+++ b/stravalib/tests/unit/test_model.py
@@ -55,7 +55,9 @@ class TestLegacyModelSerialization:
             {"distance": 100.0},
             UnitConverter("meters")(100.0),
         ),
-        (Activity, {'timezone': 'Europe/Amsterdam'}, pytz.timezone('Europe/Amsterdam'))
+        (Activity, {'timezone': 'Europe/Amsterdam'}, pytz.timezone('Europe/Amsterdam')),
+        (Club, {'activity_types': ['Run', 'Ride']}, ['Run', 'Ride']),
+        (Activity, {'sport_type': 'Run'}, 'Run')
     ),
 )
 def test_backward_compatibility_mixin_field_conversions(


### PR DESCRIPTION
Closes #330

## Description

Fixes enum lookup behavior. Enums in the model should be converted to their basic value for backward compatibility. Pydantic should support this out of the box by providing config, but unfortunately, it doesn't work for collections of enums in model subclasses (see https://github.com/pydantic/pydantic/issues/5005).

This fixes the order of attribute lookup because enums do not raise `AttributeError` when being assigned new attributes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Does your PR include tests

- [x] Yes

## Did you include your contribution to the change log?

NA, will happen when merging into master
