### PR TITLE
Adds some Strava API changes, and datamodel-code-generator bug fix

### DIFF
--- a/stravalib/field_conversions.py
+++ b/stravalib/field_conversions.py
@@ -1,11 +1,12 @@
 import logging
 from datetime import timedelta
-from enum import Enum
 from functools import wraps
-from typing import Any, Callable, List, Optional, Sequence
+from typing import Any, Callable, List, Optional, Sequence, Union
 
 import pytz
 from pytz.exceptions import UnknownTimeZoneError
+
+from stravalib.strava_model import ActivityType, SportType
 
 LOGGER = logging.getLogger(__name__)
 
@@ -22,9 +23,9 @@ def optional_input(field_conversion_fn: Callable) -> Callable:
 
 
 @optional_input
-def enum_value(v: Enum) -> Any:
+def enum_value(v: Union[ActivityType, SportType]) -> str:
     try:
-        return v.value
+        return v.__root__
     except AttributeError:
         LOGGER.warning(
             f"{v} is not an enum, returning itself instead of its value"
@@ -33,7 +34,7 @@ def enum_value(v: Enum) -> Any:
 
 
 @optional_input
-def enum_values(enums: Sequence[Enum]) -> List:
+def enum_values(enums: Sequence[Union[ActivityType, SportType]]) -> List:
     # Pydantic (1.x) has config for using enum values, but unfortunately
     # it doesn't work for lists of enums.
     # See https://github.com/pydantic/pydantic/issues/5005

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 from datetime import date, datetime
 from functools import wraps
-from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple, get_args
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple, Union, get_args
 
 from pydantic import BaseModel, Field, root_validator, validator
 from pydantic.datetime_parse import parse_datetime
@@ -83,9 +83,13 @@ def lazy_property(fn):
 
 # Custom validators for some edge cases:
 
-def check_valid_location(location: Optional[List[float]]) -> Optional[List[float]]:
-    # location for activities without GPS may be returned as empty list
-    return location if location else None
+def check_valid_location(location: Optional[Union[List[float], str]]) -> Optional[List[float]]:
+    # legacy serialized form is str, so in case of attempting to de-serialize from local storage:
+    try:
+        return [float(l) for l in location.split(',')]
+    except AttributeError:
+        # location for activities without GPS may be returned as empty list by Strava
+        return location if location else None
 
 
 def naive_datetime(value: Optional[Any]) -> Optional[datetime]:

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 from datetime import date, datetime
 from functools import wraps
-from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple, get_args
 
 from pydantic import BaseModel, Field, root_validator, validator
 from pydantic.datetime_parse import parse_datetime
@@ -658,7 +658,7 @@ class Activity(DetailedActivity, BackwardCompatibilityMixin, DeprecatedSerializa
 
     # Added for backward compatibility
     # TODO maybe deprecate?
-    TYPES: ClassVar[Tuple] = tuple(t.value for t in ActivityType)
+    TYPES: ClassVar[Tuple] = get_args(ActivityType.__fields__['__root__'].type_)
 
     # Undocumented attributes:
     guid: Optional[str] = None

--- a/stravalib/strava_model.py
+++ b/stravalib/strava_model.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
 from typing import Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field, conint
@@ -41,48 +40,49 @@ class ActivityTotal(BaseModel):
     """
 
 
-class ActivityType(Enum):
+class ActivityType(BaseModel):
+    __root__: Literal[
+        "AlpineSki",
+        "BackcountrySki",
+        "Canoeing",
+        "Crossfit",
+        "EBikeRide",
+        "Elliptical",
+        "Golf",
+        "Handcycle",
+        "Hike",
+        "IceSkate",
+        "InlineSkate",
+        "Kayaking",
+        "Kitesurf",
+        "NordicSki",
+        "Ride",
+        "RockClimbing",
+        "RollerSki",
+        "Rowing",
+        "Run",
+        "Sail",
+        "Skateboard",
+        "Snowboard",
+        "Snowshoe",
+        "Soccer",
+        "StairStepper",
+        "StandUpPaddling",
+        "Surfing",
+        "Swim",
+        "Velomobile",
+        "VirtualRide",
+        "VirtualRun",
+        "Walk",
+        "WeightTraining",
+        "Wheelchair",
+        "Windsurf",
+        "Workout",
+        "Yoga",
+    ]
     """
     An enumeration of the types an activity may have. Note that this enumeration does not include new sport types (e.g. MountainBikeRide, EMountainBikeRide), activities with these sport types will have the corresponding activity type (e.g. Ride for MountainBikeRide, EBikeRide for EMountainBikeRide)
     """
-
-    AlpineSki = "AlpineSki"
-    BackcountrySki = "BackcountrySki"
-    Canoeing = "Canoeing"
-    Crossfit = "Crossfit"
-    EBikeRide = "EBikeRide"
-    Elliptical = "Elliptical"
-    Golf = "Golf"
-    Handcycle = "Handcycle"
-    Hike = "Hike"
-    IceSkate = "IceSkate"
-    InlineSkate = "InlineSkate"
-    Kayaking = "Kayaking"
-    Kitesurf = "Kitesurf"
-    NordicSki = "NordicSki"
-    Ride = "Ride"
-    RockClimbing = "RockClimbing"
-    RollerSki = "RollerSki"
-    Rowing = "Rowing"
-    Run = "Run"
-    Sail = "Sail"
-    Skateboard = "Skateboard"
-    Snowboard = "Snowboard"
-    Snowshoe = "Snowshoe"
-    Soccer = "Soccer"
-    StairStepper = "StairStepper"
-    StandUpPaddling = "StandUpPaddling"
-    Surfing = "Surfing"
-    Swim = "Swim"
-    Velomobile = "Velomobile"
-    VirtualRide = "VirtualRide"
-    VirtualRun = "VirtualRun"
-    Walk = "Walk"
-    WeightTraining = "WeightTraining"
-    Wheelchair = "Wheelchair"
-    Windsurf = "Windsurf"
-    Workout = "Workout"
-    Yoga = "Yoga"
 
 
 class BaseStream(BaseModel):
@@ -104,6 +104,33 @@ class CadenceStream(BaseStream):
     data: Optional[List[int]] = None
     """
     The sequence of cadence values for this stream, in rotations per minute
+    """
+
+
+class ClubAthlete(BaseModel):
+    admin: Optional[bool] = None
+    """
+    Whether the athlete is a club admin.
+    """
+    firstname: Optional[str] = None
+    """
+    The athlete's first name.
+    """
+    lastname: Optional[str] = None
+    """
+    The athlete's last initial.
+    """
+    member: Optional[str] = None
+    """
+    The athlete's member status.
+    """
+    owner: Optional[bool] = None
+    """
+    Whether the athlete is club owner.
+    """
+    resource_state: Optional[int] = None
+    """
+    Resource state, indicates level of detail. Possible values: 1 -> "meta", 2 -> "summary", 3 -> "detail"
     """
 
 
@@ -302,70 +329,81 @@ class Split(BaseModel):
     """
 
 
-class SportType(Enum):
+class SportType(BaseModel):
+    __root__: Literal[
+        "AlpineSki",
+        "BackcountrySki",
+        "Badminton",
+        "Canoeing",
+        "Crossfit",
+        "EBikeRide",
+        "Elliptical",
+        "EMountainBikeRide",
+        "Golf",
+        "GravelRide",
+        "Handcycle",
+        "HighIntensityIntervalTraining",
+        "Hike",
+        "IceSkate",
+        "InlineSkate",
+        "Kayaking",
+        "Kitesurf",
+        "MountainBikeRide",
+        "NordicSki",
+        "Pickleball",
+        "Pilates",
+        "Racquetball",
+        "Ride",
+        "RockClimbing",
+        "RollerSki",
+        "Rowing",
+        "Run",
+        "Sail",
+        "Skateboard",
+        "Snowboard",
+        "Snowshoe",
+        "Soccer",
+        "Squash",
+        "StairStepper",
+        "StandUpPaddling",
+        "Surfing",
+        "Swim",
+        "TableTennis",
+        "Tennis",
+        "TrailRun",
+        "Velomobile",
+        "VirtualRide",
+        "VirtualRow",
+        "VirtualRun",
+        "Walk",
+        "WeightTraining",
+        "Wheelchair",
+        "Windsurf",
+        "Workout",
+        "Yoga",
+    ]
     """
     An enumeration of the sport types an activity may have. Distinct from ActivityType in that it has new types (e.g. MountainBikeRide)
     """
 
-    AlpineSki = "AlpineSki"
-    BackcountrySki = "BackcountrySki"
-    Canoeing = "Canoeing"
-    Crossfit = "Crossfit"
-    EBikeRide = "EBikeRide"
-    Elliptical = "Elliptical"
-    EMountainBikeRide = "EMountainBikeRide"
-    Golf = "Golf"
-    GravelRide = "GravelRide"
-    Handcycle = "Handcycle"
-    Hike = "Hike"
-    IceSkate = "IceSkate"
-    InlineSkate = "InlineSkate"
-    Kayaking = "Kayaking"
-    Kitesurf = "Kitesurf"
-    MountainBikeRide = "MountainBikeRide"
-    NordicSki = "NordicSki"
-    Ride = "Ride"
-    RockClimbing = "RockClimbing"
-    RollerSki = "RollerSki"
-    Rowing = "Rowing"
-    Run = "Run"
-    Sail = "Sail"
-    Skateboard = "Skateboard"
-    Snowboard = "Snowboard"
-    Snowshoe = "Snowshoe"
-    Soccer = "Soccer"
-    StairStepper = "StairStepper"
-    StandUpPaddling = "StandUpPaddling"
-    Surfing = "Surfing"
-    Swim = "Swim"
-    TrailRun = "TrailRun"
-    Velomobile = "Velomobile"
-    VirtualRide = "VirtualRide"
-    VirtualRun = "VirtualRun"
-    Walk = "Walk"
-    WeightTraining = "WeightTraining"
-    Wheelchair = "Wheelchair"
-    Windsurf = "Windsurf"
-    Workout = "Workout"
-    Yoga = "Yoga"
 
-
-class StreamType(Enum):
+class StreamType(BaseModel):
+    __root__: Literal[
+        "time",
+        "distance",
+        "latlng",
+        "altitude",
+        "velocity_smooth",
+        "heartrate",
+        "cadence",
+        "watts",
+        "temp",
+        "moving",
+        "grade_smooth",
+    ]
     """
     An enumeration of the supported types of streams.
     """
-
-    time = "time"
-    distance = "distance"
-    latlng = "latlng"
-    altitude = "altitude"
-    velocity_smooth = "velocity_smooth"
-    heartrate = "heartrate"
-    cadence = "cadence"
-    watts = "watts"
-    temp = "temp"
-    moving = "moving"
-    grade_smooth = "grade_smooth"
 
 
 class SummaryActivity(MetaActivity):
@@ -612,9 +650,7 @@ class SummaryClub(MetaClub):
     """
     URL to a 60x60 pixel profile picture.
     """
-    sport_type: Optional[
-        Literal["cycling", "running", "triathlon", "other"]
-    ] = None
+    sport_type: Optional[Literal["cycling", "running", "triathlon", "other"]] = None
     """
     Deprecated. Prefer to use activity_types.
     """
@@ -851,6 +887,39 @@ class AltitudeStream(BaseStream):
     """
 
 
+class ClubActivity(BaseModel):
+    athlete: Optional[MetaAthlete] = None
+    distance: Optional[float] = None
+    """
+    The activity's distance, in meters
+    """
+    elapsed_time: Optional[int] = None
+    """
+    The activity's elapsed time, in seconds
+    """
+    moving_time: Optional[int] = None
+    """
+    The activity's moving time, in seconds
+    """
+    name: Optional[str] = None
+    """
+    The name of the activity
+    """
+    sport_type: Optional[SportType] = None
+    total_elevation_gain: Optional[float] = None
+    """
+    The activity's total elevation gain.
+    """
+    type: Optional[ActivityType] = None
+    """
+    Deprecated. Prefer to use sport_type
+    """
+    workout_type: Optional[int] = None
+    """
+    The activity's workout type
+    """
+
+
 class ClubAnnouncement(BaseModel):
     athlete: Optional[SummaryAthlete] = None
     club_id: Optional[int] = None
@@ -973,9 +1042,7 @@ class ExplorerSegment(BaseModel):
     """
     The category of the climb [0, 5]. Higher is harder ie. 5 is Hors catégorie, 0 is uncategorized in climb_category. If climb_category = 5, climb_category_desc = HC. If climb_category = 2, climb_category_desc = 3.
     """
-    climb_category_desc: Optional[
-        Literal["NC", "4", "3", "2", "1", "HC"]
-    ] = None
+    climb_category_desc: Optional[Literal["NC", "4", "3", "2", "1", "HC"]] = None
     """
     The description for the category of the climb
     """

--- a/stravalib/tests/resources/strava_swagger.json
+++ b/stravalib/tests/resources/strava_swagger.json
@@ -1982,11 +1982,11 @@
         ],
         "responses": {
           "200": {
-            "description": "A list of summary athlete representations.",
+            "description": "A list of club athlete representations.",
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "https://developers.strava.com/swagger/athlete.json#/SummaryAthlete"
+                "$ref": "https://developers.strava.com/swagger/athlete.json#/ClubAthlete"
               }
             },
             "examples": {
@@ -2093,7 +2093,7 @@
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "https://developers.strava.com/swagger/activity.json#/SummaryActivity"
+                "$ref": "https://developers.strava.com/swagger/activity.json#/ClubActivity"
               }
             },
             "examples": {

--- a/stravalib/tests/unit/test_field_conversions.py
+++ b/stravalib/tests/unit/test_field_conversions.py
@@ -1,5 +1,3 @@
-from enum import Enum
-
 import pytest
 import pytz
 
@@ -9,6 +7,7 @@ from stravalib.field_conversions import (
     optional_input,
     timezone,
 )
+from stravalib.strava_model import ActivityType, SportType
 
 
 def test_optional_input():
@@ -20,18 +19,12 @@ def test_optional_input():
     assert foo(None) is None
 
 
-class Foo(Enum):
-    FOO = "foo"
-    BAR = "bar"
-
-
-@pytest.mark.parametrize("arg,expected_value", ((Foo.FOO, "foo"), (42, 42)))
-def test_enum_value(arg, expected_value):
-    assert enum_value(arg) == expected_value
+def test_enum_value():
+    assert enum_value(ActivityType(__root__='Run')) == 'Run'
 
 
 def test_enum_values():
-    assert enum_values([Foo.FOO, 42, Foo.BAR]) == ["foo", 42, "bar"]
+    assert enum_values([ActivityType(__root__='Run'), SportType(__root__='Ride')]) == ["Run", "Ride"]
 
 
 @pytest.mark.parametrize(

--- a/stravalib/tests/unit/test_model.py
+++ b/stravalib/tests/unit/test_model.py
@@ -11,12 +11,15 @@ from stravalib import unithelper as uh
 from stravalib.model import (
     Activity,
     ActivityLap,
+    ActivityPhoto,
     ActivityTotals,
     BackwardCompatibilityMixin,
     BaseEffort,
     BoundClientEntity,
     Club,
+    LatLon,
     Segment,
+    SegmentExplorerResult,
     SubscriptionCallback,
 )
 from stravalib.strava_model import LatLng
@@ -70,8 +73,11 @@ def test_backward_compatibility_mixin_field_conversions(
 @pytest.mark.parametrize(
     'model_class,raw,expected_value',
     (
+        (Activity, {'start_latlng': "5.4,4.3"}, LatLon(__root__=[5.4, 4.3])),
         (Activity, {'start_latlng': []}, None),
         (Segment, {'start_latlng': []}, None),
+        (SegmentExplorerResult, {'start_latlng': []}, None),
+        (ActivityPhoto, {'location': []}, None),
         (Activity, {'timezone': 'foobar'}, None),
         (Activity, {'start_date_local': '2023-01-17T11:06:07Z'}, datetime(2023, 1, 17, 11, 6, 7)),
         (BaseEffort, {'start_date_local': '2023-01-17T11:06:07Z'}, datetime(2023, 1, 17, 11, 6, 7)),


### PR DESCRIPTION
## Description

Strava introduces ClubActivity and ClubAthlete types that replace the existing SummaryActivity and SummaryAthlete types that are part of a club.

A bug fix in the datamodel-code-generator package now ensures that no enum types are created. This causes some slight changes in enum handling.

## Type of change

- [x] Other (please describe)

Strava API change

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [x] Yes