### PR TITLE
Fix: allows arithmetic and comparison between multiple quantities

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Add: Pre-commit hook + instructions and configure precommit.ci bot (@lwasser, #293)
 * Fix: Setuptools_scm bug when installing stravalib remotely via GitHub (@lwasser, #331)
 * Fix: fix LatLon unmarshal from string type (@oliverkurth, #334)
+* Fix: allows arithmetic and comparison between multiple quantities (jsamoocha, #335)
 
 ## v1.1.0
 

--- a/stravalib/tests/integration/test_client.py
+++ b/stravalib/tests/integration/test_client.py
@@ -6,6 +6,7 @@ import pytest
 import responses
 from responses import matchers
 
+import stravalib.unithelper as uh
 from stravalib.client import ActivityUploader
 from stravalib.exc import ActivityPhotoUploadFailed
 from stravalib.tests import RESOURCES_DIR
@@ -314,6 +315,19 @@ def test_get_activities(mock_strava_api, client, limit, n_raw_results, expected_
     assert len(activity_list) == expected_n_activities
     if expected_n_activities > 0:
         assert activity_list[0].name == 'test_activity'
+
+
+def test_get_activities_quantity_addition(mock_strava_api, client):
+    mock_strava_api.get(
+        '/athlete/activities',
+        response_update={'distance': 1000.0},
+        n_results=2
+    )
+    act_list = list(client.get_activities(limit=2))
+    total_d = uh.meters(0)
+    total_d += act_list[0].distance
+    total_d += act_list[1].distance
+    assert total_d == uh.meters(2000.)
 
 
 def test_get_activities_paged(mock_strava_api, client):

--- a/stravalib/tests/unit/test_unithelper.py
+++ b/stravalib/tests/unit/test_unithelper.py
@@ -54,3 +54,15 @@ def test_is_quantity_type(obj, expected_result, expected_warning):
             assert uh.is_quantity_type(obj) == expected_result
     else:
         assert uh.is_quantity_type(obj) == expected_result
+
+
+def test_legacy_accessors():
+    assert uh.meters(10).num == 10
+    assert uh.meters(10).unit == 'meter'
+
+def test_arithmetic_comparison_support():
+    assert int(uh.meters(2.1)) == 2
+    assert float(uh.meters(2.1)) == 2.1
+    assert uh.meters(2) == uh.meters(2)
+    assert uh.meters(2) > uh.meters(1)
+    assert uh.meters(2) + uh.meters(1) == uh.meters(3)

--- a/stravalib/unit_registry.py
+++ b/stravalib/unit_registry.py
@@ -1,0 +1,4 @@
+from pint import UnitRegistry
+
+ureg = UnitRegistry()
+Q_ = ureg.Quantity

--- a/stravalib/unithelper.py
+++ b/stravalib/unithelper.py
@@ -77,14 +77,14 @@ def is_quantity_type(obj: Any):
 
 meter = meters = UnitConverter('m')
 second = seconds = UnitConverter('s')
-hour = hours = UnitConverter('h')
+hour = hours = UnitConverter('hour')
 foot = feet = UnitConverter('ft')
 mile = miles = UnitConverter('mi')
 kilometer = kilometers = UnitConverter('km')
 
 meters_per_second = UnitConverter('m/s')
-miles_per_hour = mph = UnitConverter('mi/h')
-kilometers_per_hour = kph = UnitConverter('km/h')
+miles_per_hour = mph = UnitConverter('mi/hour')
+kilometers_per_hour = kph = UnitConverter('km/hour')
 kilogram = kilograms = kg = kgs = UnitConverter('kg')
 pound = pounds = lb = lbs = UnitConverter('lb')
 


### PR DESCRIPTION
closes #335 

## Description

The `Quantity` class meant to provide backward compatibility with the `units` package did not correctly handle arithmetic and comparison operators. This corrects the issue.

## Type of change

Select the statement best describes this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

## Does your PR include tests

- [x] Yes

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.
