### PR TITLE
Fix: pin pydata sphinx theme to avoid icon error issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ pytest
 pytest-cov
 
 # Docs
-pydata-sphinx-theme
+# Pinning to avoid a current bug in 0.13
+pydata-sphinx-theme==0.12.0
 # Support pydantic autodoc
 autodoc_pydantic
 sphinx_remove_toctrees


### PR DESCRIPTION
This just fixes the current PR where docs are not building due to a bug in the [pydata sphinx theme ](https://github.com/pydata/pydata-sphinx-theme/issues/1226)

docs work with version 0.12 so i'm pinning to that version until i see the bug is fixed. 

