### PR TITLE
Bumps Flask for example code

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: Bumps Flask version in example code (@jsamoocha, #366)
+
 ## v1.3.0
 
 ### Added

--- a/examples/strava-oauth/requirements.txt
+++ b/examples/strava-oauth/requirements.txt
@@ -1,1 +1,1 @@
-Flask~=1.0.2
+Flask


### PR DESCRIPTION
This is necessary to prevent the reported security vulnerability https://github.com/stravalib/stravalib/security/dependabot/1.
