### PR TITLE
Hotfix: pin to pydantic v1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Package deps
 arrow
 pint
-pydantic
+pydantic==1.10.9
 pytz
 requests>=2.0,<3.0dev
 responses
@@ -22,7 +22,7 @@ types-Flask
 
 # Docs
 # Pinning to avoid a current bug in 0.13
-pydata-sphinx-theme==0.12.0
+pydata-sphinx-theme
 # Support pydantic autodoc
 autodoc_pydantic
 sphinx_remove_toctrees


### PR DESCRIPTION
## Description

The introduction of Pydantic 2.0 led to (at least) one failure in stravalib. This pins pydantic to the (current) latest v1.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Does your PR include tests

- [x] This change doesn't require tests

## Did you include your contribution to the change log?

NA, this PR is nothing but a cherry-picked commit from a feature branch.
