### PR TITLE
Fix: minor enhancement in naive_datetime types

### DIFF
--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -15,7 +15,18 @@ from __future__ import annotations
 import logging
 from datetime import date, datetime
 from functools import wraps
-from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple, Union, get_args
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Literal,
+    NewType,
+    Optional,
+    Tuple,
+    Union,
+    get_args,
+)
 
 from pydantic import BaseModel, Field, root_validator, validator
 from pydantic.datetime_parse import parse_datetime
@@ -121,7 +132,11 @@ def check_valid_location(
         return location if location else None
 
 
-def naive_datetime(value: Optional[Any]) -> Optional[datetime]:
+# Create alias for this type so docs are more user-readable
+AllDateTypes = NewType("AllDateTypes", Union[datetime, str, bytes, int, float])
+
+
+def naive_datetime(value: Optional[AllDateTypes]) -> Optional[datetime]:
     if value:
         dt = parse_datetime(value)
         return dt.replace(tzinfo=None)


### PR DESCRIPTION
This is just a tiny modification to make typing for naive_datetime more explicit. We will need to modify it to not use pydantic in the future but for now by typing it following parse_datetime specs it will be easier to understand inputs when we write more tests.  we may want to not accept certain of these formats and can have a discussion about what types of datetime formats we will accept here.

## Description



## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This is a documentation update
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [x] This change doesn't require tests

## Did you include your contribution to the change log?

- [ ] Yes, `changelog.md` is up-to-date.

*If you are having a hard time getting the tests to run correctly feel free to
ping one of the maintainers here!*

this is so small i didn't add a changelog update.
