### PR TITLE
Fix:  model.py docstrings and typing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ stravalib/tests/test.ini
 stravalib/docs/api
 .vscode/
 stravalib-2023/
+noxfile.py
+.nox/*

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ examples/strava-oauth/settings.cfg
 stravalib/tests/test.ini-example
 stravalib/tests/test.ini
 stravalib/docs/api
+.vscode/
+stravalib-2023/

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,8 @@
 - Update client's stream method to warn when using unofficial parameters (@enadeau, #385)
 - Type annotation to client file (@enadeau, #384)
 - Fix docstring in SleepingRateLimitRule (@enadeau)
-- fix: rename `SubscriptionCallback.validate` -> `SubscriptionCallback.validate_token` to avoid conflict with `pydantic.BaseModel` (@lwasser, #394)
+- Fix: rename `SubscriptionCallback.validate` -> `SubscriptionCallback.validate_token` to avoid conflict with `pydantic.BaseModel` (@lwasser, #394)
+- Fix: docstrings in model.py, documentation errors, findfonts warning suppression by removing opengraph (temporarily), typing (@lwasser)
 
 ## v1.3.3
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@
 - Type annotation to client file (@enadeau, #384)
 - Fix docstring in SleepingRateLimitRule (@enadeau)
 - Fix: rename `SubscriptionCallback.validate` -> `SubscriptionCallback.validate_token` to avoid conflict with `pydantic.BaseModel` (@lwasser, #394)
-- Fix: docstrings in model.py, documentation errors, findfonts warning suppression by removing opengraph (temporarily), typing (@lwasser)
+- Fix: docstrings in model.py, documentation errors, findfonts warning suppression by removing opengraph (temporarily), typing updates (@lwasser, #387)
 
 ## v1.3.3
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,7 +113,7 @@ html_theme_options = {
     "show_toc_level": 1,
     # "navbar_align": "left",  # [left, content, right] For testing that the navbar items align properly
     "github_url": "https://github.com/stravalib/stravalib",
-    "footer_items": ["copyright"],
+    "footer_start": ["copyright"],
 }
 
 html_context = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "myst_nb",
     "sphinx_design",
-    "sphinxext.opengraph",
+    # "sphinxext.opengraph",
     "sphinx_inline_tabs",
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,8 @@ extensions = [
     "sphinx.ext.autosummary",
     "myst_nb",
     "sphinx_design",
+    # Commented out because matplotlib raises a findfonts warning over and over
+    # TODO: fix is to install fonts in CI or remove opengraph
     # "sphinxext.opengraph",
     "sphinx_inline_tabs",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ files = [
     "stravalib/protocol.py",
     "stravalib/exc.py",
     "stravalib/client.py",
+    "stravalib/model.py",
 ]
 
 [tool.pydantic-mypy]

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ types-pytz
 types-Flask
 
 # Docs
-# Pinning to avoid a current bug in 0.13
 pydata-sphinx-theme
 # Support pydantic autodoc
 autodoc_pydantic
@@ -33,4 +32,6 @@ sphinx_copybutton
 sphinx_design
 
 # Support for social / adds meta tags
-sphinxext-opengraph
+# Removing this for the time being to avoid issues with matplotlib / findfonts
+# bug
+#sphinxext-opengraph

--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -21,6 +21,7 @@ from typing import (
     Iterable,
     Literal,
     NoReturn,
+    Optional,
     Protocol,
     TypeVar,
     cast,
@@ -1822,7 +1823,7 @@ class Client:
         self,
         raw: dict[str, Any],
         verify_token: str = model.Subscription.VERIFY_TOKEN_DEFAULT,
-    ) -> dict[str, str]:
+    ) -> dict[str, Optional[str]]:
         """Validate callback request and return valid response with challenge.
 
         Parameters
@@ -1833,7 +1834,7 @@ class Client:
 
         Returns
         -------
-        Dict[str, str]
+        dict[str, str]
             The JSON response expected by Strava to the challenge request.
 
         """

--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -21,7 +21,6 @@ from typing import (
     Iterable,
     Literal,
     NoReturn,
-    Optional,
     Protocol,
     TypeVar,
     cast,
@@ -1823,7 +1822,7 @@ class Client:
         self,
         raw: dict[str, Any],
         verify_token: str = model.Subscription.VERIFY_TOKEN_DEFAULT,
-    ) -> dict[str, Optional[str]]:
+    ) -> dict[str, str]:
         """Validate callback request and return valid response with challenge.
 
         Parameters
@@ -1840,10 +1839,11 @@ class Client:
         """
         callback = model.SubscriptionCallback.deserialize(raw)
         callback.validate_token(verify_token)
+
+        assert callback.hub_challenge is not None
         response_raw = {"hub.challenge": callback.hub_challenge}
         return response_raw
 
-    # TODO: i'm not sure what raw's "type" is here
     def handle_subscription_update(
         self, raw: dict[str, Any]
     ) -> model.SubscriptionUpdate:

--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -1471,13 +1471,13 @@ class Client:
             Indicates desired number of data points. 'low' (100), 'medium'
             (1000) or 'high' (10000).
             .. deprecated::
-                This param is not officialy supported by the Strava API and may be
+                This param is not officially supported by the Strava API and may be
                 removed in the future.
         series_type : str, optional
             Relevant only if using resolution either 'time' or 'distance'.
             Used to index the streams if the stream is being reduced.
             .. deprecated::
-                This param is not officialy supported by the Strava API and may be
+                This param is not officially supported by the Strava API and may be
                 removed in the future.
 
         Returns
@@ -1532,7 +1532,7 @@ class Client:
         results.
 
         Streams types are: time, latlng, distance, altitude, velocity_smooth,
-                           heartrate, cadence, watts, temp, moving, grade_smooth
+                            heartrate, cadence, watts, temp, moving, grade_smooth
 
         Parameters
         ----------
@@ -1544,19 +1544,19 @@ class Client:
             Indicates desired number of data points. 'low' (100), 'medium'
             (1000) or 'high' (10000).
             .. deprecated::
-                This param is not officialy supported by the Strava API and may be
-                removed in the future.
+                This param is not officially supported by the Strava API and
+                may be removed in the future.
         series_type : str, optional
             Relevant only if using resolution either 'time' or 'distance'.
             Used to index the streams if the stream is being reduced.
             .. deprecated::
-                This param is not officialy supported by the Strava API and may be
+                This param is not officially supported by the Strava API and may be
                 removed in the future.
 
         Returns
         -------
         py:class:`dict`
-            An dictionary of :class:`stravalib.model.Stream` from the activity
+            A dictionary of :class:`stravalib.model.Stream` from the activity
         """
         return self._get_streams(
             f"/activities/{activity_id}/streams",
@@ -1597,14 +1597,17 @@ class Client:
             Indicates desired number of data points. 'low' (100), 'medium'
             (1000) or 'high' (10000).
             .. deprecated::
-                This param is not officialy supported by the Strava API and may be
-                removed in the future.
+
+                This param is not officially supported by the Strava API and
+                may be removed in the future.
+
         series_type : str, optional
             Relevant only if using resolution either 'time' or 'distance'.
             Used to index the streams if the stream is being reduced.
             .. deprecated::
-                This param is not officialy supported by the Strava API and may be
-                removed in the future.
+
+                This param is not officially supported by the Strava API and
+                may be removed in the future.
 
         Returns
         -------
@@ -1639,7 +1642,7 @@ class Client:
         results.
 
         Streams types are: time, latlng, distance, altitude, velocity_smooth,
-                           heartrate, cadence, watts, temp, moving, grade_smooth
+        heartrate, cadence, watts, temp, moving, grade_smooth
 
         Parameters
         ----------
@@ -1651,13 +1654,13 @@ class Client:
             Indicates desired number of data points. 'low' (100), 'medium'
             (1000) or 'high' (10000).
             .. deprecated::
-                This param is not officialy supported by the Strava API and may be
+                This param is not officially supported by the Strava API and may be
                 removed in the future.
         series_type : str, optional
             Relevant only if using resolution either 'time' or 'distance'.
             Used to index the streams if the stream is being reduced.
             .. deprecated::
-                This param is not officialy supported by the Strava API and may be
+                This param is not officially supported by the Strava API and may be
                 removed in the future.
 
         Returns

--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -19,7 +19,6 @@ from typing import (
     Deque,
     Generic,
     Iterable,
-    List,
     Literal,
     NoReturn,
     Protocol,
@@ -960,7 +959,7 @@ class Client:
 
     def get_activity_zones(
         self, activity_id: int
-    ) -> List[model.BaseActivityZone]:
+    ) -> list[model.BaseActivityZone]:
         """Gets zones for activity.
 
         Requires premium account.

--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -19,6 +19,7 @@ from typing import (
     Deque,
     Generic,
     Iterable,
+    List,
     Literal,
     NoReturn,
     Protocol,
@@ -959,7 +960,7 @@ class Client:
 
     def get_activity_zones(
         self, activity_id: int
-    ) -> list[model.BaseActivityZone]:
+    ) -> List[model.BaseActivityZone]:
         """Gets zones for activity.
 
         Requires premium account.

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -1051,6 +1051,7 @@ class Activity(
     splits_metric: Optional[List[Split]] = None
     splits_standard: Optional[List[Split]] = None
     photos: Optional[ActivityPhotoMeta] = None
+    # TODO Detailed activity has this defined as - Optional[List[Lap]]
     laps: Optional[List[ActivityLap]] = None
 
     # Added for backward compatibility

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -251,7 +251,7 @@ class DeprecatedSerializableMixin(BaseModel):
         """
         # TODO: Argument 1 to "warn_method_deprecation" has incompatible type "str"; expected "type
         exc.warn_method_deprecation(
-            self.__class__.__name__,
+            self.__class__
             "from_dict()",
             "parse_obj()",
             "https://docs.pydantic.dev/usage/models/#helper-functions",

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -16,6 +16,7 @@ import logging
 from datetime import date, datetime
 from functools import wraps
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
@@ -33,7 +34,6 @@ from pydantic.datetime_parse import parse_datetime
 
 from stravalib import exc
 from stravalib import unithelper as uh
-from stravalib.client import BatchedResultsIterator
 from stravalib.field_conversions import enum_value, enum_values, time_interval, timezone
 from stravalib.strava_model import (
     ActivityStats,
@@ -64,6 +64,9 @@ from stravalib.strava_model import (
     SummarySegmentEffort,
     TimedZoneRange,
 )
+
+if TYPE_CHECKING:
+    from stravalib.client import BatchedResultsIterator
 
 LOGGER = logging.getLogger(__name__)
 

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -69,8 +69,8 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
-# TODO: stravalib/model.py:71: error: Please use "Callable[[<parameters>], <return type>]"  [misc]
-def lazy_property(fn: Callable[Any]) -> property:
+# TODO: how do you properly type this with more precision than Any?
+def lazy_property(fn: Callable[Any], Any) -> property:
     """
     Should be used to decorate the functions that return a lazily loaded
     entity (collection), e.g., the members of a club.

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -156,6 +156,7 @@ def check_valid_location(
 # Create alias for this type so docs are more user-readable
 AllDateTypes = NewType("AllDateTypes", Union[datetime, str, bytes, int, float])
 
+
 def naive_datetime(value: Optional[AllDateTypes]) -> Optional[datetime]:
     """Utility helper that parses a datetime value provided in
     JSON, string, int or other formats and returns a datetime.datetime
@@ -258,13 +259,13 @@ class DeprecatedSerializableMixin(BaseModel):
         ----------
             The `to_dict()` method is deprecated in favor of `dict()` method.
             For more details, refer to the Pydantic documentation:
-            https://docs.pydantic.dev/usage/exporting_models/
+            https://docs.pydantic.dev/1.10/usage/exporting_models/
         """
         warn_method_deprecation(
             self.__class__.__name__,
             "to_dict()",
             "dict()",
-            "https://docs.pydantic.dev/usage/exporting_models/",
+            "https://docs.pydantic.dev/1.10/usage/exporting_models/",
         )
         return self.dict()
 

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -13,6 +13,7 @@ related entities from the API.
 from __future__ import annotations
 
 import logging
+import warnings
 from datetime import date, datetime
 from functools import wraps
 from typing import (
@@ -358,9 +359,7 @@ class LatLon(LatLng, BackwardCompatibilityMixin, DeprecatedSerializableMixin):
     # this error doesn't make sense as the types are correct based on what the
     # error says it wants to see. so why is it throwing the error?
     @root_validator
-    def check_valid_latlng(
-        cls, values: List[Optional[float]]
-    ) -> Optional[List[float]]:
+    def check_valid_latlng(cls, values: List[float]) -> Optional[List[float]]:
         """Validate that Strava returned an actual lat/lon rather than an empty
         list. If list is empty, return None
 
@@ -601,10 +600,12 @@ class Athlete(
             The string representation of the athlete type.
         """
 
-        athlete_type = {0: "cyclist", 1: "runner"}
-        if raw_type in [0, 1]:
-            return athlete_type.get(raw_type)
+        if raw_type == 0:
+            return "cyclist"
+        elif raw_type == 1:
+            return "runner"
         else:
+            warnings.warn(f"Unknown athlete type value: {raw_type}")
             return None
 
     @lazy_property

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -613,12 +613,12 @@ class Athlete(
     @lazy_property
     def authenticated_athlete(self) -> Athlete:
         """
-        Returns an `stravalib.Client` object containing Strava account data
+        Returns an `Athlete` object containing Strava account data
         for the (authenticated) athlete.
 
         Returns
         -------
-        DetailedAthlete
+        Athlete
             The detailed information of the authenticated athlete.
         """
         assert self.bound_client is not None, "Bound client is not set."

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -137,8 +137,22 @@ def check_valid_location(
 # Create alias for this type so docs are more user-readable
 AllDateTypes = NewType("AllDateTypes", Union[datetime, str, bytes, int, float])
 
-
 def naive_datetime(value: Optional[AllDateTypes]) -> Optional[datetime]:
+    """Utility helper that parses a datetime value provided in
+    JSON, string, int or other formats and returns a datetime.datetime
+    object
+
+    Parameters
+    ----------
+    value : str, int
+        A value representing a date/time that may be presented in string,
+        int, deserialized or other format.
+
+    Returns
+    -------
+    datetime.datetime
+        A datetime object representing the datetime input value.
+    """
     if value:
         dt = parse_datetime(value)
         return dt.replace(tzinfo=None)
@@ -227,7 +241,10 @@ class BackwardCompatibilityMixin:
         return value
 
 
+# TODO: add better description of this
 class BoundClientEntity(BaseModel):
+    """Description of this class goes here."""
+
     # Using Any as type here to prevent catch-22 between circular import and
     # pydantic forward-referencing issues "resolved" by PEP-8 violations.
     # See e.g. https://github.com/pydantic/pydantic/issues/1873
@@ -417,13 +434,18 @@ class Athlete(
         return self.is_authenticated
 
 
+# TODO: better description
 class ActivityComment(Comment):
-    # Field overrides from superclass for type extensions:
+    """Field overrides from superclass for type extensions"""
+
     athlete: Optional[Athlete] = None
 
 
 class ActivityPhotoPrimary(Primary):
-    # Undocumented attributes:
+    """The primary photo for an activity.
+    Attributes are Undocumented
+    """
+
     use_primary_photo: Optional[bool] = None
 
 
@@ -533,6 +555,8 @@ class ActivityLap(
 
 
 class Map(PolylineMap):
+    """Pass through object. Inherits from PolyLineMap"""
+
     pass
 
 
@@ -713,7 +737,7 @@ class BaseEffort(
     Base class for a best effort or segment effort.
     """
 
-    # field overrides from superclass for type extensions:
+    # Field overrides from superclass for type extensions:
     segment: Optional[Segment] = None
     activity: Optional[Activity] = None
     athlete: Optional[Athlete] = None
@@ -733,6 +757,8 @@ class BestEffort(BaseEffort):
     """
     Class representing a best effort (e.g. best time for 5k)
     """
+
+    pass
 
 
 class SegmentEffort(BaseEffort):

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -582,7 +582,6 @@ class Athlete(
             The string representation of the athlete type.
         """
 
-        # TODO: Pylance - Expression of type "str | None" cannot be assigned to
         # return type "str"
         return {0: "cyclist", 1: "runner"}.get(raw_type)
 

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -13,7 +13,6 @@ related entities from the API.
 from __future__ import annotations
 
 import logging
-import warnings
 from datetime import date, datetime
 from functools import wraps
 from typing import (
@@ -605,7 +604,7 @@ class Athlete(
         elif raw_type == 1:
             return "runner"
         else:
-            warnings.warn(f"Unknown athlete type value: {raw_type}")
+            LOGGER.warning(f"Unknown athlete type value: {raw_type}")
             return None
 
     @lazy_property

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -601,7 +601,7 @@ class Athlete(
     @lazy_property
     def stats(self) -> AthleteStats:
         """
-        A method that grabs statistics for an (authenticated) athlete.
+        Grabs statistics for an (authenticated) athlete.
 
         Returns
         -------
@@ -639,15 +639,18 @@ class Athlete(
         return self.is_authenticated
 
 
-# TODO: better description <- <leah unsure of what the field override part is>?
+# TODO: better description
+# TODO: What is the goal of this attr override?
 class ActivityComment(Comment):
-    """Field overrides from superclass for type extensions"""
+    """Field overrides the athlete attribute to be of type :class:`Athlete`
+    rather than :class:`SummaryAthlete`
+    """
 
     athlete: Optional[Athlete] = None
 
 
 class ActivityPhotoPrimary(Primary):
-    """The primary photo for an activity.
+    """Represents the primary photo for an activity.
 
     Notes
     -----
@@ -725,9 +728,10 @@ class ActivityPhoto(BackwardCompatibilityMixin, DeprecatedSerializableMixin):
         )
 
 
+# TODO: this wasn't working as intended - test again
 class ActivityKudos(Athlete):
     """
-    Information about kudos an athlete received on an activity.
+    Represents kudos an athlete received on an activity.
 
     Notes
     -----

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -20,8 +20,6 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Dict,
-    List,
     Literal,
     Optional,
     Tuple,
@@ -125,8 +123,8 @@ def lazy_property(fn: Callable[Any]) -> property:
 
 
 def check_valid_location(
-    location: Optional[Union[List[float], str]]
-) -> Optional[List[float]]:
+    location: Optional[Union[list[float], str]]
+) -> Optional[list[float]]:
     """
     Parameters
     ----------
@@ -195,17 +193,17 @@ class DeprecatedSerializableMixin(BaseModel):
     """
 
     # TODO: i used the output type from this class
-    # could Dict also be an int or float??
+    # could dict also be an int or float??
     @classmethod
     def deserialize(
-        cls, attribute_value_mapping: Dict[str, str]
+        cls, attribute_value_mapping: dict[str, str]
     ) -> DeprecatedSerializableMixin:
         """
         Creates and returns a new object based on serialized (dict) struct.
 
         Parameters
         ----------
-        attribute_value_mapping : Dict
+        attribute_value_mapping : dict
             A dictionary representing the serialized data.
 
         Returns
@@ -230,15 +228,15 @@ class DeprecatedSerializableMixin(BaseModel):
         )
         return cls.parse_obj(attribute_value_mapping)
 
-    # TODO: Same question here about Dict elements (strings or str, Union[str,int])
-    def from_dict(self, attribute_value_mapping: Dict[str, str]) -> None:
+    # TODO: Same question here about dict elements (strings or str, Union[str,int])
+    def from_dict(self, attribute_value_mapping: dict[str, str]) -> None:
         """
         Deserializes v into self, resetting and ond/or overwriting existing
         fields
 
         Parameters
         ----------
-        attribute_value_mapping : Dict
+        attribute_value_mapping : dict
             A dictionary that will be deserialized into the parent object.
 
         Deprecated
@@ -260,13 +258,13 @@ class DeprecatedSerializableMixin(BaseModel):
         # TODO - calling self.__init__ directly is not recommended because it may lead to unexpected behavior,
         self.__init__(**self.parse_obj(attribute_value_mapping).dict())
 
-    def to_dict(self) -> Dict[str, str]:
+    def to_dict(self) -> dict[str, str]:
         """
         Returns a dict representation of self
 
         Returns
         -------
-        Dict
+        dict
             A dictionary containing the data from the instance.
 
         Deprecated
@@ -358,8 +356,8 @@ class LatLon(LatLng, BackwardCompatibilityMixin, DeprecatedSerializableMixin):
 
     @root_validator
     def check_valid_latlng(
-        cls, values: List[Optional[float]]
-    ) -> Optional[List[Optional[float]]]:
+        cls, values: list[Optional[float]]
+    ) -> Optional[list[Optional[float]]]:
         """Validate that Strava returned an actual lat/lon rather than an empty
         list. If list is empty, return None
 
@@ -372,7 +370,7 @@ class LatLon(LatLng, BackwardCompatibilityMixin, DeprecatedSerializableMixin):
         Returns
         -------
         list or None
-            List of lat/lon values or None
+            list of lat/lon values or None
 
         """
         # Strava sometimes returns empty list in case of activities without GPS
@@ -438,7 +436,7 @@ class Club(
 
         Returns
         -------
-        List
+        list
             A list of club members stored as Athlete objects.
         """
         assert self.bound_client is not None, "Bound client is not set."
@@ -542,14 +540,14 @@ class Athlete(
     # Field overrides from superclass for type extensions:
     # TODO: these overrides make mypy upset - i think this might be related to the circular assignment??
     # stravalib/model.py:535: error: Incompatible types in assignment (expression
-    # has type "Optional[List[Club]]", base class "DetailedAthlete" defined the
-    # type as "Optional[List[SummaryClub]]")  [assignment]
-    # stravalib/model.py:536: error: Incompatible types in assignment (expression has type "Optional[List[Bike]]", base class "DetailedAthlete" defined the type as "Optional[List[SummaryGear]]")  [assignment]
-    clubs: Optional[List[SummaryClub]] = None
-    # mypy wants these below to be Optional[List[SummaryGear]] as that is
+    # has type "Optional[list[Club]]", base class "DetailedAthlete" defined the
+    # type as "Optional[list[SummaryClub]]")  [assignment]
+    # stravalib/model.py:536: error: Incompatible types in assignment (expression has type "Optional[list[Bike]]", base class "DetailedAthlete" defined the type as "Optional[list[SummaryGear]]")  [assignment]
+    clubs: Optional[list[SummaryClub]] = None
+    # mypy wants these below to be Optional[list[SummaryGear]] as that is
     # what is defined in the DetailedAthlete class in strava_model
-    bikes: Optional[List[Bike]] = None
-    shoes: Optional[List[Shoe]] = None
+    bikes: Optional[list[Bike]] = None
+    shoes: Optional[list[Shoe]] = None
 
     # Undocumented attributes:
     is_authenticated: Optional[bool] = None
@@ -589,7 +587,7 @@ class Athlete(
     admin: Optional[bool] = None
     owner: Optional[bool] = None
     # TODO: can permission take other inputs other than bool?
-    subscription_permissions: Optional[List[bool]] = None
+    subscription_permissions: Optional[list[bool]] = None
 
     @validator("athlete_type")
     def to_str_representation(cls, raw_type: int) -> Optional[str]:
@@ -720,9 +718,9 @@ class ActivityPhoto(BackwardCompatibilityMixin, DeprecatedSerializableMixin):
     created_at: Optional[datetime] = None
     created_at_local: Optional[datetime] = None
     location: Optional[LatLon] = None
-    urls: Optional[Dict[str, str]] = None
+    urls: Optional[dict[str, str]] = None
     # TODO - is this a float return?
-    sizes: Optional[Dict[str, float]] = None
+    sizes: Optional[dict[str, float]] = None
     post_id: Optional[int] = None
     default_photo: Optional[bool] = None
     source: Optional[int] = None
@@ -1029,7 +1027,7 @@ class SegmentEffort(BaseEffort):
     Class representing a best effort on a particular segment.
     """
 
-    achievements: Optional[List[SegmentEffortAchievement]] = None
+    achievements: Optional[list[SegmentEffortAchievement]] = None
 
 
 class Activity(
@@ -1048,14 +1046,14 @@ class Activity(
     end_latlng: Optional[LatLon] = None
     map: Optional[Map] = None
     gear: Optional[Gear] = None
-    # TODO: Incompatible types in assignment (expression has type "Optional[List[BestEffort]]", base class "DetailedActivity" defined the type as "Optional[List[DetailedSegmentEffort]]")
-    best_efforts: Optional[List[DetailedSegmentEffort]] = None
-    segment_efforts: Optional[List[DetailedSegmentEffort]] = None
-    splits_metric: Optional[List[Split]] = None
-    splits_standard: Optional[List[Split]] = None
+    # TODO: Incompatible types in assignment (expression has type "Optional[list[BestEffort]]", base class "DetailedActivity" defined the type as "Optional[list[DetailedSegmentEffort]]")
+    best_efforts: Optional[list[DetailedSegmentEffort]] = None
+    segment_efforts: Optional[list[DetailedSegmentEffort]] = None
+    splits_metric: Optional[list[Split]] = None
+    splits_standard: Optional[list[Split]] = None
     photos: Optional[ActivityPhotoMeta] = None
-    # TODO Detailed activity has this defined as - Optional[List[Lap]]
-    laps: Optional[List[ActivityLap]] = None
+    # TODO Detailed activity has this defined as - Optional[list[Lap]]
+    laps: Optional[list[ActivityLap]] = None
 
     # Added for backward compatibility
     # TODO maybe deprecate?
@@ -1120,9 +1118,9 @@ class Activity(
     # The conditional added her addresses this
     # "error: Item "None" of "Optional[Any]" has no attribute "get_activity_zones"  [union-attr]"
     # This error appears several times. i just don't understand how
-    # bound client could be None OR do i need to use OptionalList[BaseActivityZone] ??
+    # bound client could be None OR do i need to use Optionallist[BaseActivityZone] ??
     @lazy_property
-    def zones(self) -> List[BaseActivityZone]:
+    def zones(self) -> list[BaseActivityZone]:
         """Retrieve a list of zones for an activity.
 
         Returns
@@ -1168,7 +1166,7 @@ class BaseActivityZone(
     """
 
     # field overrides from superclass for type extensions:
-    distribution_buckets: Optional[List[DistributionBucket]] = None
+    distribution_buckets: Optional[list[DistributionBucket]] = None
 
     # overriding the superclass type: it should also support pace as value
     # TODO: how do we handle this with mypy (distribution_buckets above has the same issue) when we override - this happens several times
@@ -1187,7 +1185,7 @@ class Stream(
 
     # Not using the typed subclasses from the generated model
     # for backward compatibility:
-    data: Optional[List[Any]] = None
+    data: Optional[list[Any]] = None
 
 
 class Route(
@@ -1205,7 +1203,7 @@ class Route(
     map: Optional[Map] = None
     # TODO: base class Route defines this as a list of SummarySegments
     # Line 1373 in strava_model.py - are we intentionally overriding?
-    segments: Optional[List[Segment]]
+    segments: Optional[list[Segment]]
 
     _field_conversions = {"distance": uh.meters, "elevation_gain": uh.meters}
 
@@ -1283,7 +1281,7 @@ class SubscriptionUpdate(
     object_type: Optional[str] = None
     aspect_type: Optional[str] = None
     event_time: Optional[datetime] = None
-    updates: Optional[Dict] = None
+    updates: Optional[dict] = None
 
 
 SegmentEffort.update_forward_refs()

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -357,7 +357,7 @@ class LatLon(LatLng, BackwardCompatibilityMixin, DeprecatedSerializableMixin):
     @root_validator
     def check_valid_latlng(
         cls, values: List[Optional[float]]
-    ) -> Optional[List[Optional[float]]]:
+    ) -> Optional[List[float]]:
         """Validate that Strava returned an actual lat/lon rather than an empty
         list. If list is empty, return None
 

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -354,6 +354,9 @@ class LatLon(LatLng, BackwardCompatibilityMixin, DeprecatedSerializableMixin):
     Enables backward compatibility for legacy namedtuple
     """
 
+    # TODO: stravalib/model.py:377: error: Incompatible return value type (got "Optional[List[Optional[float]]]", expected "Optional[List[float]]")  [return-value]
+    # this error doesn't make sense as the types are correct based on what the
+    # error says it wants to see. so why is it throwing the error?
     @root_validator
     def check_valid_latlng(
         cls, values: List[Optional[float]]
@@ -544,7 +547,7 @@ class Athlete(
 
     # Undocumented attributes:
     is_authenticated: Optional[bool] = None
-    athlete_type: Optional[int] = None
+    athlete_type: Optional[Literal["cyclist", "runner"]] = None
     friend: Optional[str] = None
     follower: Optional[str] = None
     approve_followers: Optional[bool] = None
@@ -581,8 +584,10 @@ class Athlete(
     owner: Optional[bool] = None
     subscription_permissions: Optional[List[bool]] = None
 
-    @validator("athlete_type")
-    def to_str_representation(cls, raw_type: int) -> Optional[str]:
+    @validator("athlete_type", pre=True)
+    def to_str_representation(
+        cls, raw_type: int
+    ) -> Optional[Literal["cyclist", "runner"]]:
         """Replaces legacy 'ChoicesAttribute' class.
 
         Parameters

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -582,7 +582,7 @@ class Athlete(
     subscription_permissions: Optional[List[bool]] = None
 
     @validator("athlete_type")
-    def to_str_representation(cls, raw_type: int) -> str:
+    def to_str_representation(cls, raw_type: int) -> Optional[str]:
         """Replaces legacy 'ChoicesAttribute' class.
 
         Parameters
@@ -597,7 +597,10 @@ class Athlete(
         """
 
         athlete_type = {0: "cyclist", 1: "runner"}
-        return athlete_type.get(raw_type)
+        if raw_type in [0, 1]:
+            return athlete_type.get(raw_type)
+        else:
+            return None
 
     @lazy_property
     def authenticated_athlete(self) -> Athlete:

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -28,7 +28,6 @@ from typing import (
     TypeVar,
     Union,
     get_args,
-    no_type_check,
 )
 
 from pydantic import BaseModel, Field, root_validator, validator
@@ -1250,8 +1249,7 @@ class SubscriptionCallback(
 
     # TODO: Signature of "validate" incompatible with supertype "BaseModel"
     # [override] - we should consider renaming this method??
-    #@no_type_check
-    def validate(
+    def validate_token(
         self, verify_token: str = Subscription.VERIFY_TOKEN_DEFAULT
     ) -> None:
         """

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -70,7 +70,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 # TODO: how do you properly type this with more precision than Any?
-def lazy_property(fn: Callable[Any], Any) -> property:
+def lazy_property(fn: Callable[[Any], Any]) -> property:
     """
     Should be used to decorate the functions that return a lazily loaded
     entity (collection), e.g., the members of a club.


### PR DESCRIPTION
closes #375 

This should fix 375 - the warning when building docs

## Description

This is a small issue
1. if docs are missing docstrings they won't appear at all in the documentation.
2. If a class inherits from another class but is missing a pass, it also can't render properly making it difficult for pydantic-autodoc to properly render the expected JSON.

This fixes that issue in model.py and also addresses a few other docstring related items.

## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x ] This is a documentation update
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [x] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.

