### PR TITLE
Add: nox config for docs, tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ stravalib/_version_generated.py
 examples/strava-oauth/settings.cfg
 # Code cov
 .coverage
+.nox
+.vscode/*
+docs/_build/*
 
 # so people don't mistakenly delete and submit a pr with these
 stravalib/tests/test.ini-example

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,6 +13,7 @@ build:
     python: "3.10"
 
 python:
+  version: 3.10
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,6 @@ build:
     python: "3.10"
 
 python:
-  version: 3.10
   install:
     - method: pip
       path: .

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
 - Type annotation to client file (@enadeau, #384)
 - Add: issue templates for easier debugging / guide users (@lwasser, #408)
 - Fix: read the docs is breaking due to pydantic json warnings, also update python version on build and sync pr previews (@lwasser, #412)
+- Fix: update master to main in all builds (@lwasser)
 
 ### Contributors to this release
 

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 
 - Type annotation to client file (@enadeau, #384)
 - Add: issue templates for easier debugging / guide users (@lwasser, #408)
+- Fix: read the docs is breaking due to pydantic json warnings, also update python version on build and sync pr previews (@lwasser, #412)
 
 ### Contributors to this release
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add: Add nox to run tests & build docs (@lwasser, #395)
+
 ## v1.4
 
 ### Fixed

--- a/docs/contributing/build-release-guide.md
+++ b/docs/contributing/build-release-guide.md
@@ -76,7 +76,7 @@ To make a release:
 
 Below you can see an example of what these changelog changes looked like when
 we bumped to version 1.0 of stravalib.
-_(Some fo the original change log content is removed to keep this page shorter)_
+_(Some of the original change log content is removed to keep this page shorter)_
 
 ```
 ## Unreleased

--- a/docs/contributing/build-release-guide.md
+++ b/docs/contributing/build-release-guide.md
@@ -8,6 +8,7 @@ For packaging we use `setuptools` for packaging and the `build` package to
 create a wheel and distribution for pushing to PyPI.
 
 ## Package versioning
+
 To keep track of stravalib versioning, we use `setuptools_scm`. Setuptools_scm
 is a behind the scenes tool that uses the most current tag in the repository
 to determine what version of the package is being built.
@@ -19,8 +20,7 @@ If you build the package locally, the `_version_generated.py` file should NEVER
 be committed to version control. It should be ignored via our `.gitignore` file
 ```
 
-If you wish to build stravalib locally to check out the .whl and distribution
-tarball you can use:
+If you wish to build stravalib locally to check out the .whl and source distribution (SDist):
 
 ```
 make build
@@ -28,7 +28,7 @@ make build
 
 When you run `make build`, it will do a few things
 
-1. it will create a `dist` directory with the wheel and the tarball distributions of the package in it. You can see the version of `stravalib` in the name of those files:
+1. it will create a `dist` directory with the wheel and the package SDist tarball. You can see the version of `stravalib` in the name of those files:
 
 ```bash
 dist/
@@ -52,14 +52,14 @@ in the GitHub.com interface if you wish.
 
 We follow [semantic version](https://semver.org/) best practices for our release workflow as follows:
 
-* MAJOR version when you make incompatible API changes
-* MINOR version when you add functionality in a backwards compatible manner
-* PATCH version when you make backwards compatible bug fixes
+- MAJOR version when you make incompatible API changes
+- MINOR version when you add functionality in a backwards compatible manner
+- PATCH version when you make backwards compatible bug fixes
 
 ### How to make a release to PyPI
 
 ```{note}
-The build workflow explained below will run and push to test PyPI on every merge to the master branch of stravalib. Thus before you create a pull request to initiate a new release, please check out stravalib on [test pypi](https://pypi.org/project/stravalib/) to:
+The build workflow explained below will run and push to test PyPI on every merge to the main branch of stravalib. Thus before you create a pull request to initiate a new release, please check out stravalib on [test pypi](https://pypi.org/project/stravalib/) to:
 
 1. Make sure that the README file and other elements are rendering properly
 2. You can also install the package from test PyPI as an additional check!
@@ -67,15 +67,16 @@ The build workflow explained below will run and push to test PyPI on every merge
 
 To make a release:
 
-* ✔️ 1. Determine with the other maintainers what release version we are moving to. This can be done in an issue.
-* ✔️ 2. Create a new **pull request** using the release pull request template that does the following:
+- ✔️ 1. Determine with the other maintainers what release version we are moving to. This can be done in an issue.
+- ✔️ 2. Create a new **pull request** using the release pull request template that does the following:
 
-    * Organizes the changelog.md unreleased items into added, fixed and changed sections
-    * Lists contributors to this release using GitHub handles
-    * Adds the version number of that specific release.
+  - Organizes the changelog.md unreleased items into added, fixed and changed sections
+  - Lists contributors to this release using GitHub handles
+  - Adds the version number of that specific release.
 
-Below you can see an example of what these changelog changes looked like when we bumped to
-version 1.0 of stravalib. *(Some fo the original change log content is removed to keep this page shorter)*
+Below you can see an example of what these changelog changes looked like when
+we bumped to version 1.0 of stravalib.
+_(Some fo the original change log content is removed to keep this page shorter)_
 
 ```
 ## Unreleased
@@ -101,10 +102,11 @@ version 1.0 of stravalib. *(Some fo the original change log content is removed t
 
 ```
 
-* ✔️ 3. Once another maintainer approves the pull request, you can merge it.
+- ✔️ 3. Once another maintainer approves the pull request, you can merge it.
 
 You are now ready to make the actual release.
-* ✔️ 4. In GitHub.com go to `Releases` and prepare a new release. When you create that release you can specify the tag for this release.
+
+- ✔️ 4. In GitHub.com go to `Releases` and prepare a new release. When you create that release you can specify the tag for this release.
 
 Use `v` in the tag number to maintain consistency with previous releases.
 
@@ -112,13 +114,11 @@ This is the ONLY manual step in the release workflow. Be sure to create the corr
 
 Copy the updated changelog information into the body of the release.
 
-* ✔️ 5. Now hit `publish release`.
+- ✔️ 5. Now hit `publish release`.
 
 When you publish the release, a GitHub action will be enabled that will:
 
-1. build the wheel and tarball and
-2. push the distribution to PyPI!
-
-
+1. build the wheel and SDist and
+2. publish the distribution to PyPI
 
 Congratulations! You've just created a release of stravalib!

--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -1,22 +1,25 @@
-# Development Guide for Anyone Who Wants to Contribute to Stravalib
+# Development Guide for Contributing to Stravalib
 
 ```{note}
  * Please make sure that you've read our [contributing guide](how-to-contribute.md)
 before reading this guide.
 * If you are looking for information on our package build structure and release workflow please see our build and [release guide](build-release-guide)
 ```
-The steps to get started with contributing to stravalib are below. You will begin
-by forking and cloning our Github repository.
+
+The steps to get started with contributing to stravalib are below. You will
+begin by forking and cloning our Github repository.
 
 ## Fork and clone the stravalib repository
 
 ### 1. Fork the repository on GitHub
+
 To create your own copy of the stravalib repository on GitHub, navigate to the
 [stravalib/stravalib](https://github.com/stravalib/stravalib) repository
 and click the **Fork** button in the top-right corner of the page.
 
 ### 2. Clone your fork locally
-Next, use ``git clone`` to create a local copy of your stravalib forked
+
+Next, use `git clone` to create a local copy of your stravalib forked
 repository on your local filesystem:
 
 ```bash
@@ -28,6 +31,7 @@ Once you have cloned your forked repository locally, you are ready to create a
 development environment.
 
 ## Setup a local development environment
+
 We suggest that you create a virtual environment on your computer to work on
 `stravalib`. Below, we show you how to do that using a `conda` environment. However,
 you are welcome to use pip / `virtualenv` or whatever environment manager that
@@ -38,10 +42,10 @@ you prefer!
 The instructions below assume that you have a conda enabled Python distribution.
 Anaconda and miniconda are examples of two conda python distributions.
 If you are unsure of which distribution to use,
-[we suggest miniconda](https://docs.conda.io/en/latest/miniconda.html) as it is a
-lighter weight installation that will minimize environment conflicts given it has
-fewer packages and tools bundled with it compared to the much larger Anaconda
-distribution.
+[we suggest miniconda](https://docs.conda.io/en/latest/miniconda.html) as it is
+a lighter weight installation that will minimize environment conflicts given
+it has fewer packages and tools bundled with it compared to the much larger
+Anaconda distribution.
 
 To begin, install the conda environment.
 This will create a local conda environment called `stravalib_dev`
@@ -73,12 +77,15 @@ $ pip install -e .
 
 Stravalib contains the following main components:
 
-At the core, a (pydantic) domain model is generated and updated by a bot via pull requests.
-This model reflects the officially published API specification by Strava and is stored in
-the module `strava_model.py`. This file should never be edited  manually. Instead, the stravalib bot will suggest changes to the model through pull requests that can then be merged by stravalib maintainers.
+At the core, a (pydantic) domain model is generated and updated by a bot via
+pull requests. This model reflects the officially published API specification
+by Strava and is stored in the module `strava_model.py`. This file should never
+be edited manually. Instead, the stravalib bot will suggest changes to the
+model through pull requests that can then be merged by stravalib maintainers.
 
 The module `model.py` contains classes that inherit from the
-official Strava domain model in `strava_model.py`. This module supports custom typing, unit conversion, (de-)serialization behavior, and support for
+official Strava domain model in `strava_model.py`. This module supports custom
+typing, unit conversion, (de-)serialization behavior, and support for
 undocumented Strava features.
 
 The module `protocol.py` manages the sending of HTTP requests
@@ -86,21 +93,20 @@ to Strava and handling the received responses (including rate limiting).
 It is used by methods in `client.py` to de-serialize raw response data into
 the domain entities in `model.py`.
 
-
-## Code style and linting
+## Code style, linting & typing
 
 We use the following tools to ensure consistent code format that follows
 the Python Enhancement Protocol (PEP) 008 standards. These standards dictate
 best practices for Python code readability and consistency:
 
-* [black](https://black.readthedocs.io/en/stable/) for consistent code format
-that generally follows [PEP 8 guidlines](https://peps.python.org/pep-0008/).
-Because black's default line length is 88 characters, we adjust it to 79
-characters in the config [to follow PEP 8 line width guidelines](https://peps.python.org/pep-0008/#maximum-line-length).
-* [isort](https://pycqa.github.io/isort/): ensure imports are ordered following [PEP 8 import guidelines](https://peps.python.org/pep-0008/#imports)
-* [flake8](https://flake8.pycqa.org/en/latest/): flake8 is a linter. It identifies other PEP 8 issues in the code that Black will not address including comments that extend beyond 79
-characters and doc string line width. It also will identify unused imports and
-unused but declared variables.
+- [black](https://black.readthedocs.io/en/stable/) for consistent code format
+  that generally follows [PEP 8 guidlines](https://peps.python.org/pep-0008/).
+  Because black's default line length is 88 characters, we adjust it to 79
+  characters in the config [to follow PEP 8 line width guidelines](https://peps.python.org/pep-0008/#maximum-line-length).
+- [isort](https://pycqa.github.io/isort/): ensure imports are ordered following [PEP 8 import guidelines](https://peps.python.org/pep-0008/#imports)
+- [flake8](https://flake8.pycqa.org/en/latest/): flake8 is a linter. It identifies other PEP 8 issues in the code that Black will not address including comments that extend beyond 79
+  characters and doc string line width. It also will identify unused imports and
+  unused but declared variables.
 
 For local development, you can use our [`pre-commit` hook setup](https://pre-commit.com/).
 When installed, the pre-commit hook will run each code format
@@ -109,9 +115,9 @@ commit to your local clone of stravalib. If your code doesn't "pass" checks for
 each tool then the following happens:
 
 1. If it's a `black` or `isort` error, the code will be fixed / updated by black
-and/or isort.
+   and/or isort.
 2. If it's a `flake8` error, flake8 will provide you with a list of
-issues in your code. You will need to fix each individually by hand.
+   issues in your code. You will need to fix each individually by hand.
 
 ### Setup and run the pre-commit hooks
 
@@ -155,7 +161,6 @@ To call the bot on a pull request, add the text:
 as a single line comment in the pull request. The bot will automatically run
 all of the hooks that it is configured to run.
 
-
 ```{tip}
 If you have an open Pull Request but you need to make some changes locally,
 and the bot has already run on your pull request and added a commit, you can
@@ -174,7 +179,25 @@ force the branch to be in the same commit state as your local branch.
 
 ```
 
+### Typing using mypy
+
+To ensure proper typing throughout our library we use [mypy](https://mypy.readthedocs.io/). To run mypy across python versions use:
+
+`nox -s mypy`
+
+Similar to running tests, if you are missing a version of Python, nox will
+skip that run and continue to the next version.
+
+```python
+❯ nox -s mypy
+nox > Running session mypy-3.8
+nox > Missing interpreters will error by default on CI systems.
+nox > Session mypy-3.8 skipped: Python interpreter 3.8 not found.
+nox > Running session mypy-3.9
+```
+
 ## Code format and syntax
+
 If you are contributing code to `stravalib`, please be sure to follow PEP 8
 syntax best practices.
 
@@ -182,14 +205,13 @@ syntax best practices.
 
 **All docstrings** should follow the
 [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard).
-All functions/classes/methods should have docstrings with a full description of all
-arguments and return values.
+All functions/classes/methods should have docstrings with a full description of
+all arguments and return values.
 
 ```{warning}
 This also will be updated once we implement a code styler
-While the maximum line length for code is automatically set by *Black*, docstrings
-must be formatted manually. To play nicely with Jupyter and IPython, **keep docstrings
-limited to 79 characters** per line.
+While the maximum line length for code is automatically set by *Black*,
+docstrings must be formatted manually. To play nicely with Jupyter and IPython, **limit docstrings to 79 characters** per line.
 ```
 
 ## About the stravalib test suite
@@ -199,19 +221,20 @@ sets of tests that you can run:
 
 1. functional end-to-end test suite: this test set requires an API key to run.
 1. unit tests that are setup to run on CI. These tests use mock
-instances of the API to avoid needed to setup an API key yourself locally.
+   instances of the API to avoid needed to setup an API key yourself locally.
 
 ### Unit - and integration test suite
 
 ```{warning}
 We will add more information about the test suite in the near future.
 
-For integration tests that should be run independently from Strava, there's a pytest
-fixture :func:`~stravalib.tests.integration.conftest.mock_strava_api`
+For integration tests that should be run independently from Strava, there's a
+pytest fixture :func:`~stravalib.tests.integration.conftest.mock_strava_api`
 that is based on :class:`responses.RequestsMock`.
-It prevents requests being made to the actual Strava API and instead registers responses
-that are based on examples from the published Strava API documentation. Example usages of
-this fixture can be found in the :mod:`stravalib.tests.integration.test_client` module.
+This fixture, prevents requests being made to the actual Strava API and instead
+registers responses that are based on examples from the published Strava API
+documentation. Example usages of this fixture can be found in the
+:mod:`stravalib.tests.integration.test_client` module.
 ```
 
 We have setup the test suite to run on the stravalib package as installed.
@@ -223,26 +246,32 @@ You can run the tests using make as specified below. Note that when you run
 the tests this way, they will run in a temporary environment to ensure that
 they are running against the installed version of the package that you are working on.
 
-To run the test suite use:
+To run the test suite across all python versions that we support use:
 
 ```
-make test
+nox -s test
 ```
 
-`make test` does a few things:
+`nox -s test` does a few things:
 
 1. It create a temporary directory called `tmp-test-dir-stravalib` in which your tests are run. We create this test directory to ensure that tests are being run against the installed version of stravalib (with the most recent local development changes as installed) rather than the flat files located in the GitHub repository.
 2. It runs the tests and provides output (see below)
 3. Finally it removes the temporary directory
 
+If you are a conda/mamba user, you can use:
+
+```
+nox -s test_mamba
+```
 
 ### Functional end-to-end test suite
+
 The functional (end-to-end) test suite is set up to hit the STRAVA api.
 You will thus need an app setup in your Strava account to run the test suite.
-We recommend that you create a dummy account for this with a single activity to avoid
-any chances of your data being unintentionally modified. Once you have the app setup
-and a valid access_token for an account with at least one activity, follow the steps
-below.
+We recommend that you create a dummy account for this with a single activity
+to avoid any chances of your data being unintentionally modified. Once you have
+the app setup and a valid access_token for an account with at least one
+activity, follow the steps below.
 
 1. Rename the file `stravalib/stravalib/tests/test.ini-example` to `test.ini`
 2. Add your API token to the file by replacing:
@@ -250,6 +279,7 @@ below.
 ```bash
 access_token = xxxxxxxxxxxxxxxx
 ```
+
 with:
 
 ```bash
@@ -272,20 +302,20 @@ You are now ready to run the test suite. To run tests on python 3.x run:
 $ pytest
 ```
 
-
 ### Test code coverage
-We use [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/) to calculate
-test coverage. When you run `make test` pytest-cov will provide you with coverage
-outputs locally. You can ignore the returned values for any files in the `test`
-directory.
 
-Example output from `make test`:
+We use [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/) to calculate
+test coverage. When you run `make test` pytest-cov will provide you with
+coverage outputs locally. You can ignore the returned values for any files in
+the `test` directory.
+
+Example output from `nox -s test`:
 
 ```bash
 pytest --cov stravalib stravalib/tests/unit stravalib/tests/integration
 =================================================== test session starts ===================================================
 platform darwin -- Python 3.8.13, pytest-7.2.0, pluggy-1.0.0
-rootdir: /Users/leahawasser/Documents/GitHub/stravalib
+rootdir: .../stravalib
 plugins: cov-4.0.0
 collected 105 items
 
@@ -314,6 +344,7 @@ TOTAL
 ```
 
 ### Code coverage reporting on pull requests with codecov
+
 We use an integration with [codecov.io](https://about.codecov.io) to report test coverage
 changes on every pull request. This report will appear in your pull request once
 all of the GitHub action checks have run.
@@ -325,6 +356,7 @@ actions completes, the report will be processed and returned to the pull request
 ```
 
 ## Documentation
+
 `Stravalib` documentation is created using `sphinx` and the
 [`furo`](https://pradyunsg.me/furo/quickstart/) theme.
 `Stravalib` documentation is hosted on [ReadtheDocs](https://readthedocs.org).
@@ -344,24 +376,26 @@ readthedocs build is passing or failing.
 Currently @hozn, @lwasser and @jsamoocha have access to the readthedocs `stravalib`
 documentation build
 
-Online documentation will be updated on all merges to the master branch of
+Online documentation will be updated on all merges to the main branch of
 `stravalib`.
 
 ### Build documentation locally
+
 To build the documentation, first activate your stravalib development
 environment which has all of the packages required to build the documentation.
 Then, use the command:
 
 ```bash
-$ make -C docs
+$ nox -s docs
 ```
 
 This command:
-* Builds documentation
-* Builds `stravalib` API reference documentation using docstrings within the package
-* Checks for broken links
 
-After running `make -C docs` you can view the built documentation in a web
+- Builds documentation
+- Builds `stravalib` API reference documentation using docstrings within the package
+- Checks for broken links
+
+After running `nox -s docs` you can view the built documentation in a web
 browser locally by opening the following file on your computer:
 
 ```
@@ -379,7 +413,7 @@ This allows you to see your edits automatically as you are working on the
 text files of the documentation. To run the live server use:
 
 ```bash
-$ make -C docs serve
+$ nox -s docs-live
 ```
 
 ```{note}
@@ -408,20 +442,24 @@ function/class/module.
 ### About the documentation CI build
 
 Once you create a pull request, GitHub actions will build the docs and
-check for any syntax or url errors. Once the PR is approved and merged into the master branch of the `stravalib/stravalib`
+check for any syntax or url errors. Once the PR is approved and merged into the main branch of the `stravalib/stravalib`
 repository, the docs will build and be [available at the readthedocs website](https://stravalib.readthedocs.io/en/latest/).
 
 ### Cleanup of documentation and package build files
+
 To clean up all documentation build folders and files, run the following
 command from the root of the `stravalib` directory:
 
 ```bash
-$ make -C docs clean
+$ nox -s clean-docs
 ```
 
-To clean up build files such as the .whl file, and other temporary files creating
-when building `stravalib` run:
+To clean up build files such as the .whl file, and other temporary files
+creating when building `stravalib` run:
 
 ```bash
 $ make clean
 ```
+
+Note: we will be moving the build and this step to nox as well in the near
+future.

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ nox.options.reuse_existing_virtualenvs = True
 
 
 # Use this for venv envs nox -s test
-@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
+@nox.session(python=["3.9", "3.10", "3.11"])
 def test(session):
     session.install(".[all]")
     session.install("-r", "requirements.txt")
@@ -22,12 +22,16 @@ def test(session):
 
 
 # Use this for conda/mamba = nox -s test_mamba
-@nox.session(venv_backend="mamba", python=["3.8", "3.9", "3.10", "3.11"])
+@nox.session(venv_backend="mamba", python=["3.9", "3.10", "3.11"])
 def test_mamba(session):
     session.install(".[all]")
     session.install("-r", "requirements.txt")
     session.run(
-        "pytest", "stravalib/tests/unit/", "stravalib/tests/integration/"
+        "pytest",
+        "--cov",
+        "stravalib",
+        "stravalib/tests/unit/",
+        "stravalib/tests/integration/",
     )
 
 
@@ -59,7 +63,14 @@ def docs_live(session):
     session.run(*cmd)
 
 
-docs_dir = os.path.join("_build", "html")
+# Use this for venv envs nox -s test
+@nox.session(python=["3.9", "3.10", "3.11"])
+def mypy(session):
+    session.install(".[all]")
+    session.install("-r", "requirements.txt")
+    session.run(
+        "mypy",
+    )
 
 
 @nox.session(name="docs-clean")

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,75 @@
+import os
+import pathlib
+import shutil
+
+import nox
+
+nox.options.reuse_existing_virtualenvs = True
+
+
+# Use this for venv envs nox -s test
+@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
+def test(session):
+    session.install(".[all]")
+    session.install("-r", "requirements.txt")
+    session.run(
+        "pytest", "stravalib/tests/unit/", "stravalib/tests/integration/"
+    )
+
+
+# Use this for conda/mamba = nox -s test_mamba
+@nox.session(venv_backend="mamba", python=["3.8", "3.9", "3.10", "3.11"])
+def test_mamba(session):
+    session.install(".[all]")
+    session.install("-r", "requirements.txt")
+    session.run(
+        "pytest", "stravalib/tests/unit/", "stravalib/tests/integration/"
+    )
+
+
+# Build docs!
+build_command = ["-b", "html", "docs/", "docs/_build/html"]
+
+
+@nox.session
+def docs(session):
+    session.install("-r", "requirements.txt")
+    cmd = ["sphinx-build"]
+    cmd.extend(build_command + session.posargs)
+    session.run(*cmd)
+
+
+@nox.session(name="docs-live")
+def docs_live(session):
+    session.install("-r", "requirements.txt")
+
+    AUTOBUILD_IGNORE = [
+        "_build",
+        "build_assets",
+        "tmp",
+    ]
+    cmd = ["sphinx-autobuild"]
+    for folder in AUTOBUILD_IGNORE:
+        cmd.extend(["--ignore", f"*/{folder}/*"])
+    cmd.extend(build_command + session.posargs)
+    session.run(*cmd)
+
+
+docs_dir = os.path.join("_build", "html")
+
+
+@nox.session(name="docs-clean")
+def clean_dir(dir_path=docs_dir):
+    """
+    Clean out the docs directory used in the
+    live build.
+    """
+    dir_path = pathlib.Path(dir_path)
+    dir_contents = dir_path.glob("*")
+
+    for content in dir_contents:
+        print(content)
+        if content.is_dir():
+            shutil.rmtree(content)
+        else:
+            os.remove(content)

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,11 @@ def test(session):
     session.install(".[all]")
     session.install("-r", "requirements.txt")
     session.run(
-        "pytest", "stravalib/tests/unit/", "stravalib/tests/integration/"
+        "pytest",
+        "--cov",
+        "stravalib",
+        "stravalib/tests/unit/",
+        "stravalib/tests/integration/",
     )
 
 
@@ -59,16 +63,17 @@ docs_dir = os.path.join("_build", "html")
 
 
 @nox.session(name="docs-clean")
-def clean_dir(dir_path=docs_dir):
+def clean_docs(session):
     """
     Clean out the docs directory used in the
     live build.
     """
-    dir_path = pathlib.Path(dir_path)
+    dir_path = pathlib.Path("docs", "_build")
+    print(dir_path)
     dir_contents = dir_path.glob("*")
 
     for content in dir_contents:
-        print(content)
+        print(f"cleaning content from the {dir_path}")
         if content.is_dir():
             shutil.rmtree(content)
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pytz
 requests>=2.0,<3.0dev
 responses
 
+
 nox
 
 # Pre commit hook

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,13 @@ pytz
 requests>=2.0,<3.0dev
 responses
 
+nox
+
 # Pre commit hook
 pre-commit
 
-# Testing
+# Testing & code cov
 pytest
-# Code coverage
 pytest-cov
 
 # Type checking


### PR DESCRIPTION
closes #395

<!--- * If this pr does not address an open issue  in the repository, please be sure
to explain what this pull request fixes or does. We prefer to discuss changes in issues first, to just ensure we are all on the same page about the change being proposed.

* If this is a technical code change, please be sure that you have [read our contributing guide.](https://stravalib.readthedocs.io/en/latest/contributing/how-to-contribute.html)
-->

## Description

This change adds Nox to our build workflow. Right now we are using Make for everything. Nox is much cleaner because it's python and as such easy to read. it also supports virtual environments and running things across various versions for local debugging. 

This pr does NOT include building our package but that step will be easy to add. I just wanted folks to test it out to see if everyone is comfortable with moving to nox and removing the old-school Makefile that is much harder to read / maintain (IMO) :) with less fun features like environments and such for robust test dev locally.  ✨ 


## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [X] Other (please describe) 

This is an infrastructure update!

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [x] This change doesn't require tests

This helps us run our tests!

## Did you include your contribution to the change log?

- [ ] Yes, `changelog.md` is up-to-date.

*If you are having a hard time getting the tests to run correctly feel free to
ping one of the maintainers here!*

There is no change log yet, if folks like this approach i'll 

- [ ] add a build step
- [ ] remove make from our workflow
- [ ] update our documentation 

i was inspired to do this given the current issues with python 3.8. it's just easier to be able to run test locally on the version that i want without switching environments all of the time. 

test this out now!!

try
``` 
pip install nox
nox -s docs-live
```

docs-live session will start an interactive session where as you edit documentation files, the docs themselves will update in your browser. NOTE: i've had issues with api docs not updating but everything else should update!

```
nox -s test
```
if you use venv for environments this is for you. run tests on python 3.8 thru 3.11 locally!!
NOTE: you will need to install the various versions of python locally for this to work on your machine!

or if you are a mamba fan like me:

```
nox -s test_mamba
```

this will use conda/mamba environments!