### PR TITLE
Fix: rename validate to validate_token

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
 - Update client's stream method to warn when using unofficial parameters (@enadeau, #385)
 - Type annotation to client file (@enadeau, #384)
 - Fix docstring in SleepingRateLimitRule (@enadeau)
-- fix: rename `SubscriptionCallback.validate` -> `SubscriptionCallback.validate_token` to avoid conflict with `pydantic.BaseModel` (@lwasser, #396)
+- fix: rename `SubscriptionCallback.validate` -> `SubscriptionCallback.validate_token` to avoid conflict with `pydantic.BaseModel` (@lwasser, #394)
 
 ## v1.3.3
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: rename `SubscriptionCallback.validate` -> `SubscriptionCallback.validate_token` to avoid conflict with `pydantic.BaseModel` (@lwasser, #396)
+
 ## v1.3.3
 
 ### Fixed

--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -1720,7 +1720,7 @@ class Client(object):
 
         """
         callback = model.SubscriptionCallback.deserialize(raw)
-        callback.validate(verify_token)
+        callback.validate_token(verify_token)
         response_raw = {"hub.challenge": callback.hub_challenge}
         return response_raw
 

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -912,7 +912,7 @@ class SubscriptionCallback(
     class Config:
         alias_generator = lambda field_name: field_name.replace("hub_", "hub.")
 
-    def validate(self, verify_token=Subscription.VERIFY_TOKEN_DEFAULT):
+    def validate_token(self, verify_token=Subscription.VERIFY_TOKEN_DEFAULT):
         assert self.hub_verify_token == verify_token
 
 


### PR DESCRIPTION
closes #394



## Description

This addresses the issue of validate having the same name as pydantic.BaseModel and as such raising errors when typing stravalib... but also leaving us open to unexpected behavior. 

## Type of change

Select the statement best describes this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [x] No, i'd like some help with tests
- [ ] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.

*If you are having a hard time getting the tests to run correctly feel free to
ping one of the maintainers here!*
 
tests ARE running locally. i know that it makes sense to add some tests here but i'm still getting to know our test suite and am not quite confident enough YET to add tests. but this should fix the typing warning we are getting in #387 as a starting place. 