### PR TITLE
Add: Issue template forms for users to create better bug and documentation reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,104 @@
+name: 🐞 Bug Report
+description: Report incorrect behavior in the stravalib library
+title: "BUG: "
+labels: [Bug, help-wanted]
+
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Stravalib version checks
+      options:
+        - label: >
+            I have tested this in a new clean environment with only stravalib
+            and core python files.
+          required: true
+        - label: >
+            I have checked that this issue has not already been reported.
+          required: true
+        - label: >
+            I have confirmed this bug exists on the
+            [latest version](https://pypi.org/project/stravalib/) of stravalib.
+          required: true
+        - label: >
+            I have confirmed this bug exists on the
+            [main branch](https://github.com/stravalib/stravalib)
+            of stravalib.
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: What operating system are you seeing the problem on?
+      multiple: true
+      options:
+        - Windows
+        - Mac
+        - Linux
+  - type: textarea
+    id: python-version
+    attributes:
+      label: What version of python or you running?
+      description: >
+        Example: 3.10.12
+      placeholder: >
+        Enter the version here.
+
+        ...
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: example
+    attributes:
+      label: Reproducible Example
+      description: >
+        Please follow [this guide](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) on how to
+        provide a minimal, copy-pastable example.
+      placeholder: >
+        from stravalib.client import Client
+
+        # Your code here (please don't include token values / secrets here!)
+
+        ...
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Issue Description
+      description: >
+        Please provide a description of the issue shown in the reproducible example.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: >
+        Please describe or show a code example of the expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: version
+    attributes:
+      label: Your environment
+      description: >
+        Please paste the output of ``pip list`` or ``conda list`` here
+      value: >
+        <details>
+
+
+        Replace this line with the output of pip or conda list.
+
+
+        </details>
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/stravalib/stravalib/blob/master/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -83,7 +83,8 @@ body:
     attributes:
       label: Your environment
       description: >
-        Please paste the output of ``pip list`` or ``conda list`` here
+        Please paste the output of ``pip freeze`` or the associated conda envt
+        ``conda env export > environment.yml`` here
       value: >
         <details>
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Stravalib community support 
+    url: https://github.com/orgs/stravalib/discussions/categories/q-a
+    about: Please ask general questions about stravalib in our discussions

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
-  - name: Stravalib community support 
+  - name: Stravalib community support
     url: https://github.com/orgs/stravalib/discussions/categories/q-a
     about: Please ask general questions about stravalib in our discussions

--- a/.github/ISSUE_TEMPLATE/documentation-issue.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.yml
@@ -1,0 +1,48 @@
+name:  📝 Documentation Improvement
+description: Report wrong or missing documentation
+title: "DOC: "
+labels: [documentation]
+
+body:
+  - type: checkboxes
+    attributes:
+      label: Stravalib version checks
+      options:
+        - label: >
+            I have checked that this issue has not already been reported.
+            required: true
+        - label: >
+            I have confirmed this bug exists on the
+            [latest version](https://pypi.org/project/stravalib/) of stravalib.
+        - label: >
+            I have confirmed this bug exists on the
+            [main branch](https://github.com/stravalib/stravalib)
+            of stravalib.
+  - type: textarea
+    id: location
+    attributes:
+      label: Location of the documentation
+      description: >
+        Please provide the location of the documentation, e.g. "stravalib.Client" or the
+        URL of the documentation, e.g.
+        "https://stravalib.readthedocs.io/en/latest/reference/client.htmll"
+      placeholder: https://stravalib.readthedocs.io/en/latest/reference/client.html
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Documentation problem
+      description: >
+        Please provide a description of what documentation you believe needs
+        to be fixed/improved
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested fix for documentation
+      description: >
+        Please explain how the suggested fix improves the stravalib docs.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/documentation-issue.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.yml
@@ -40,3 +40,11 @@ body:
         Please explain how the suggested fix improves the stravalib docs.
     validations:
       required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/stravalib/stravalib/blob/master/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/documentation-issue.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.yml
@@ -9,15 +9,9 @@ body:
       label: Stravalib version checks
       options:
         - label: >
-            I have checked that this issue has not already been reported.
-            required: true
-        - label: >
-            I have confirmed this bug exists on the
-            [latest version](https://pypi.org/project/stravalib/) of stravalib.
-        - label: >
-            I have confirmed this bug exists on the
-            [main branch](https://github.com/stravalib/stravalib)
-            of stravalib.
+            I have checked that the issue still exists on the latest version of
+            the docs [here](https://stravalib.readthedocs.io/en/latest/)
+          required: true
   - type: textarea
     id: location
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -57,7 +57,7 @@ body:
       description: >
         Please provide any relevant GitHub issues, code examples or references
         that help describe and support the feature request.
-    - type: checkboxes
+  - type: checkboxes
     id: terms
     attributes:
       label: Code of Conduct

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,59 @@
+name: Feature Request
+description: Suggest an idea for stravalib
+title: "ENH: "
+labels: [feature-request]
+
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Feature Type
+      description: >
+        Please check what type of feature request you would like to propose.
+      options:
+        - label: >
+            Adding new functionality to stravalib
+        - label: >
+            Changing existing functionality in stravalib
+        - label: >
+            Removing existing functionality in stravalib
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem Description
+      description: >
+        Please describe what problem the feature would solve.
+      placeholder: >
+        I wish I could use stravalib to ...
+    validations:
+      required: true
+  - type: textarea
+    id: feature
+    attributes:
+      label: Feature Description
+      description: >
+        Please describe how the new feature would be implemented.
+        Please use pseudo-code if relevant.
+      placeholder: >
+        Your text here - pseudo-code demonstrated what this would look like
+        when used encouraged
+    validations:
+      required: true
+  - type: textarea
+    id: alternative
+    attributes:
+      label: Alternative Solutions
+      description: >
+        Please describe any alternative solution (existing functionality,
+        3rd party package, etc.) that would satisfy the feature request.
+      placeholder: >
+        Your text here.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: >
+        Please provide any relevant GitHub issues, code examples or references
+        that help describe and support the feature request.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -57,3 +57,11 @@ body:
       description: >
         Please provide any relevant GitHub issues, code examples or references
         that help describe and support the feature request.
+    - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/stravalib/stravalib/blob/master/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 - Fix docstring in SleepingRateLimitRule (@enadeau)
 - Fix: rename `SubscriptionCallback.validate` -> `SubscriptionCallback.validate_token` to avoid conflict with `pydantic.BaseModel` (@lwasser, #394)
 - Fix: docstrings in model.py, documentation errors, findfonts warning suppression by removing opengraph (temporarily), typing updates (@lwasser, #387)
+- Add: issue templates for easier debugging / guide users (@lwasser, #408)
 
 ## v1.3.3
 


### PR DESCRIPTION
closes #408

## Description

This is just a way to help guide uses to better bug reports that we can begin to evaluate more easily
you can see what the [templates look like in my repo here!](https://github.com/lwasser/stravalib/issues/new/choose)

<img width="1574" alt="Screen Shot 2023-08-16 at 12 08 04 PM" src="https://github.com/stravalib/stravalib/assets/7649194/ff089c84-6b89-4dda-9b90-650680ca431c">

## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [x] Other (please describe) this is an infrastructure update

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [x] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date. 
