### PR TITLE
Fix: read the docs failing builds given pydantic JSON output warning

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,14 @@
 version: 2
 
 sphinx:
+  builder: html
   configuration: docs/conf.py
+  fail_on_warning: false
 
 formats: all
 
 python:
-  version: 3.8
+  version: 3.10
   install:
     - method: pip
       path: .


### PR DESCRIPTION
closes #411

## Description

Our docs are currently failing builds in read the docs.


## Type of change

Select the statement best describes this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This is a documentation update
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [x] No, i'd like some help with tests
- [ ] This change doesn't require tests

## Did you include your contribution to the change log?

- [ ] Yes, `changelog.md` is up-to-date.

i didn't update the changelog on this one but could. it's pretty minor if this fix works
