### PR TITLE
Fix: update Readthedocs config file and add autobuild permissions for prs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,8 +7,12 @@ sphinx:
 
 formats: all
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
 python:
-  version: 3.10
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,14 @@
 version: 2
 
 sphinx:
+  builder: html
   configuration: docs/conf.py
+  fail_on_warning: false
 
 formats: all
 
 python:
-  version: 3.8
+  version: 3.10
   install:
     - method: pip
       path: .

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 - Fix docstring in SleepingRateLimitRule (@enadeau)
 - Fix: rename `SubscriptionCallback.validate` -> `SubscriptionCallback.validate_token` to avoid conflict with `pydantic.BaseModel` (@lwasser, #394)
 - Fix: docstrings in model.py, documentation errors, findfonts warning suppression by removing opengraph (temporarily), typing updates (@lwasser, #387)
+- Fix: read the docs is breaking due to pydantic json warnings, also update python version on build and sync pr previews (@lwasser, #412)
 
 ## v1.3.3
 


### PR DESCRIPTION
closes #411

## Description

Our docs are currently failing builds in read the docs.


## Type of change

Select the statement best describes this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This is a documentation update
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [x] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.

i didn't update the changelog on this one but could. it's pretty minor if this fix works
