### PR TITLE
Drop python 3.8 support

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and quantities through the [Python Pint library](https://pypi.org/project/Pint/)
 
 ## Dependencies
 
-* Python 3.8+
+* Python 3.9+
 * Setuptools for installing dependencies
 * Other Python libraries (installed automatically when using pip): requests, pytz, pint, arrow, pydantic
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 - Add: issue templates for easier debugging / guide users (@lwasser, #408)
 - Fix: read the docs is breaking due to pydantic json warnings, also update python version on build and sync pr previews (@lwasser, #412)
 - Fix: update master to main in all builds (@lwasser)
+- Remove python 3.8 support following NEP-29 (@enadeau, #416)
 
 ## v1.3.3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ maintainers = [
      {name = "Hans Lellelid"},
      {name = "Jonatan Samoocha"},
      {name = "Yihong"},
+     {name = "Émile Nadeau"},
     ]
 requires-python = ">=3.9"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ maintainers = [
      {name = "Jonatan Samoocha"},
      {name = "Yihong"},
     ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
@@ -39,7 +39,6 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Topic :: Software Development :: Libraries",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -75,7 +74,7 @@ filterwarnings = [
 ]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 follow_imports = "silent"
 warn_redundant_casts = true
 warn_unused_ignores = true

--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -11,6 +11,7 @@ import collections
 import functools
 import logging
 import time
+from collections.abc import Iterable
 from datetime import datetime, timedelta
 from io import BytesIO
 from typing import (
@@ -18,7 +19,6 @@ from typing import (
     Any,
     Deque,
     Generic,
-    Iterable,
     Literal,
     NoReturn,
     Protocol,
@@ -900,7 +900,7 @@ class Client:
                 activity_file = BytesIO(activity_file)
             else:
                 raise TypeError(
-                    "Invalid type specified for activity_file: {0}".format(
+                    "Invalid type specified for activity_file: {}".format(
                         type(activity_file)
                     )
                 )
@@ -1418,7 +1418,7 @@ class Client:
         if activity_type is not None:
             if activity_type not in ("riding", "running"):
                 raise ValueError(
-                    "Invalid activity type: {0}.  Possible values: {1!r}".format(
+                    "Invalid activity type: {}.  Possible values: {!r}".format(
                         activity_type, valid_activity_types
                     )
                 )
@@ -1700,7 +1700,7 @@ class Client:
             athlete_id = self.get_athlete().id
 
         result_fetcher = functools.partial(
-            self.protocol.get, "/athletes/{id}/routes".format(id=athlete_id)
+            self.protocol.get, f"/athletes/{athlete_id}/routes"
         )
 
         return BatchedResultsIterator(
@@ -1757,7 +1757,7 @@ class Client:
         """
 
         result_fetcher = functools.partial(
-            self.protocol.get, "/routes/{id}/streams/".format(id=route_id)
+            self.protocol.get, f"/routes/{route_id}/streams/"
         )
 
         streams = BatchedResultsIterator(
@@ -1981,7 +1981,7 @@ class BatchedResultsIterator(Generic[T]):
         self.reset()
 
     def __repr__(self) -> str:
-        return "<{0} entity={1}>".format(
+        return "<{} entity={}>".format(
             self.__class__.__name__, self.entity.__name__
         )
 
@@ -2017,7 +2017,7 @@ class BatchedResultsIterator(Generic[T]):
         self._buffer = collections.deque(entities)
 
         self.log.debug(
-            "Requested page {0} (got: {1} items)".format(
+            "Requested page {} (got: {} items)".format(
                 self._page, len(self._buffer)
             )
         )

--- a/stravalib/field_conversions.py
+++ b/stravalib/field_conversions.py
@@ -1,7 +1,8 @@
 import logging
+from collections.abc import Sequence
 from datetime import timedelta
 from functools import wraps
-from typing import Any, Callable, List, Optional, Sequence, Union
+from typing import Any, Callable, Optional, Union
 
 import pytz
 from pytz.exceptions import UnknownTimeZoneError
@@ -34,7 +35,7 @@ def enum_value(v: Union[ActivityType, SportType]) -> str:
 
 
 @optional_input
-def enum_values(enums: Sequence[Union[ActivityType, SportType]]) -> List:
+def enum_values(enums: Sequence[Union[ActivityType, SportType]]) -> list:
     # Pydantic (1.x) has config for using enum values, but unfortunately
     # it doesn't work for lists of enums.
     # See https://github.com/pydantic/pydantic/issues/5005

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -20,11 +20,8 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Dict,
-    List,
     Literal,
     Optional,
-    Tuple,
     TypeVar,
     Union,
     get_args,
@@ -129,8 +126,8 @@ def lazy_property(fn: Callable[[U], T]) -> Optional[T]:
 
 
 def check_valid_location(
-    location: Optional[Union[List[float], str]]
-) -> Optional[List[float]]:
+    location: Optional[Union[list[float], str]]
+) -> Optional[list[float]]:
     """
     Parameters
     ----------
@@ -258,7 +255,7 @@ class DeprecatedSerializableMixin(BaseModel):
         # returns a new object
         self.__init__(**self.parse_obj(attribute_value_mapping).dict())  # type: ignore[misc]
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Returns a dict representation of self
 
@@ -358,7 +355,7 @@ class LatLon(LatLng, BackwardCompatibilityMixin, DeprecatedSerializableMixin):
     # this error doesn't make sense as the types are correct based on what the
     # error says it wants to see. so why is it throwing the error?
     @root_validator
-    def check_valid_latlng(cls, values: List[float]) -> Optional[List[float]]:
+    def check_valid_latlng(cls, values: list[float]) -> Optional[list[float]]:
         """Validate that Strava returned an actual lat/lon rather than an empty
         list. If list is empty, return None
 
@@ -539,9 +536,9 @@ class Athlete(
     """
 
     # Field overrides from superclass for type extensions:
-    clubs: Optional[List[SummaryClub]] = None
-    bikes: Optional[List[SummaryGear]] = None
-    shoes: Optional[List[SummaryGear]] = None
+    clubs: Optional[list[SummaryClub]] = None
+    bikes: Optional[list[SummaryGear]] = None
+    shoes: Optional[list[SummaryGear]] = None
 
     # Undocumented attributes:
     is_authenticated: Optional[bool] = None
@@ -580,7 +577,7 @@ class Athlete(
     membership: Optional[str] = None
     admin: Optional[bool] = None
     owner: Optional[bool] = None
-    subscription_permissions: Optional[List[bool]] = None
+    subscription_permissions: Optional[list[bool]] = None
 
     @validator("athlete_type", pre=True)
     def to_str_representation(
@@ -720,9 +717,9 @@ class ActivityPhoto(BackwardCompatibilityMixin, DeprecatedSerializableMixin):
     created_at: Optional[datetime] = None
     created_at_local: Optional[datetime] = None
     location: Optional[LatLon] = None
-    urls: Optional[Dict[str, str]] = None
+    urls: Optional[dict[str, str]] = None
     # TODO - is this a float return?
-    sizes: Optional[Dict[str, float]] = None
+    sizes: Optional[dict[str, float]] = None
     post_id: Optional[int] = None
     default_photo: Optional[bool] = None
     source: Optional[int] = None
@@ -1025,7 +1022,7 @@ class SegmentEffort(BaseEffort):
     Class representing a best effort on a particular segment.
     """
 
-    achievements: Optional[List[SegmentEffortAchievement]] = None
+    achievements: Optional[list[SegmentEffortAchievement]] = None
 
 
 class Activity(
@@ -1044,22 +1041,22 @@ class Activity(
     end_latlng: Optional[LatLon] = None
     map: Optional[Map] = None
     gear: Optional[Gear] = None
-    best_efforts: Optional[List[DetailedSegmentEffort]] = None
-    segment_efforts: Optional[List[DetailedSegmentEffort]] = None
+    best_efforts: Optional[list[DetailedSegmentEffort]] = None
+    segment_efforts: Optional[list[DetailedSegmentEffort]] = None
     # Ignoring types here given there are overrides
-    splits_metric: Optional[List[Split]] = None  # type: ignore[assignment]
-    splits_standard: Optional[List[Split]] = None  # type: ignore[assignment]
+    splits_metric: Optional[list[Split]] = None  # type: ignore[assignment]
+    splits_standard: Optional[list[Split]] = None  # type: ignore[assignment]
     photos: Optional[ActivityPhotoMeta] = None
-    laps: Optional[List[Lap]] = None
+    laps: Optional[list[Lap]] = None
 
     # Added for backward compatibility
     # TODO maybe deprecate?
-    TYPES: ClassVar[Tuple[Any, ...]] = get_args(
+    TYPES: ClassVar[tuple[Any, ...]] = get_args(
         ActivityType.__fields__["__root__"].type_
     )
 
     # TODO this and line 1055 above changed from str to Any
-    SPORT_TYPES: ClassVar[Tuple[Any, ...]] = get_args(
+    SPORT_TYPES: ClassVar[tuple[Any, ...]] = get_args(
         SportType.__fields__["__root__"].type_
     )
 
@@ -1110,7 +1107,7 @@ class Activity(
         return self.bound_client.get_activity_comments(self.id)
 
     @lazy_property
-    def zones(self) -> List[BaseActivityZone]:
+    def zones(self) -> list[BaseActivityZone]:
         """Retrieve a list of zones for an activity.
 
         Returns
@@ -1157,7 +1154,7 @@ class BaseActivityZone(
 
     # Field overrides from superclass for type extensions:
     # Using type that is currently mimicking legacy behavior...
-    distribution_buckets: Optional[List[DistributionBucket]] = None  # type: ignore[assignment]
+    distribution_buckets: Optional[list[DistributionBucket]] = None  # type: ignore[assignment]
 
     # TODO: ignoring type given legacy support will be deprecated
     type: Optional[Literal["heartrate", "power", "pace"]] = None  # type: ignore[assignment]
@@ -1174,7 +1171,7 @@ class Stream(
 
     # Not using the typed subclasses from the generated model
     # for backward compatibility:
-    data: Optional[List[Any]] = None
+    data: Optional[list[Any]] = None
 
 
 class Route(
@@ -1190,7 +1187,7 @@ class Route(
     # Superclass field overrides for using extended types
     athlete: Optional[Athlete] = None
     map: Optional[Map] = None
-    segments: Optional[List[Segment]]  # type: ignore[assignment]
+    segments: Optional[list[Segment]]  # type: ignore[assignment]
 
     _field_conversions = {"distance": uh.meters, "elevation_gain": uh.meters}
 
@@ -1265,7 +1262,7 @@ class SubscriptionUpdate(
     object_type: Optional[str] = None
     aspect_type: Optional[str] = None
     event_time: Optional[datetime] = None
-    updates: Optional[Dict[str, Any]] = None
+    updates: Optional[dict[str, Any]] = None
 
 
 SegmentEffort.update_forward_refs()

--- a/stravalib/protocol.py
+++ b/stravalib/protocol.py
@@ -177,7 +177,7 @@ class ApiV3(metaclass=abc.ABCMeta):
             access token will expire)
         """
         response = self._request(
-            "https://{0}/oauth/token".format(self.server),
+            f"https://{self.server}/oauth/token",
             params={
                 "client_id": client_id,
                 "client_secret": client_secret,
@@ -218,7 +218,7 @@ class ApiV3(metaclass=abc.ABCMeta):
             access token will expire)
         """
         response = self._request(
-            "https://{0}/oauth/token".format(self.server),
+            f"https://{self.server}/oauth/token",
             params={
                 "client_id": client_id,
                 "client_secret": client_secret,
@@ -251,7 +251,7 @@ class ApiV3(metaclass=abc.ABCMeta):
         """
         if not url.startswith("http"):
             url = urljoin(
-                "https://{0}".format(self.server),
+                f"https://{self.server}",
                 self.api_base + "/" + url.strip("/"),
             )
         return url
@@ -306,7 +306,7 @@ class ApiV3(metaclass=abc.ABCMeta):
             requester = methods[method.upper()]
         except KeyError:
             raise ValueError(
-                "Invalid/unsupported request method specified: {0}".format(
+                "Invalid/unsupported request method specified: {}".format(
                     method
                 )
             )
@@ -350,27 +350,27 @@ class ApiV3(metaclass=abc.ABCMeta):
             pass
         else:
             if "message" in json_response or "errors" in json_response:
-                error_str = "{0}: {1}".format(
+                error_str = "{}: {}".format(
                     json_response.get("message", "Undefined error"),
                     json_response.get("errors"),
                 )
 
         # Special subclasses for some errors
         if response.status_code == 404:
-            msg = "%s: %s" % (response.reason, error_str)
+            msg = "{}: {}".format(response.reason, error_str)
             raise exc.ObjectNotFound(msg, response=response)
         elif response.status_code == 401:
-            msg = "%s: %s" % (response.reason, error_str)
+            msg = "{}: {}".format(response.reason, error_str)
             raise exc.AccessUnauthorized(msg, response=response)
         elif 400 <= response.status_code < 500:
-            msg = "%s Client Error: %s [%s]" % (
+            msg = "{} Client Error: {} [{}]".format(
                 response.status_code,
                 response.reason,
                 error_str,
             )
             raise exc.Fault(msg, response=response)
         elif 500 <= response.status_code < 600:
-            msg = "%s Server Error: %s [%s]" % (
+            msg = "{} Server Error: {} [{}]".format(
                 response.status_code,
                 response.reason,
                 error_str,
@@ -431,9 +431,7 @@ class ApiV3(metaclass=abc.ABCMeta):
         """
         referenced = self._extract_referenced_vars(url)
         url = url.format(**kwargs)
-        params = dict(
-            [(k, v) for k, v in kwargs.items() if k not in referenced]
-        )
+        params = {k: v for k, v in kwargs.items() if k not in referenced}
         return self._request(
             url, params=params, check_for_errors=check_for_errors
         )
@@ -464,9 +462,7 @@ class ApiV3(metaclass=abc.ABCMeta):
         """
         referenced = self._extract_referenced_vars(url)
         url = url.format(**kwargs)
-        params = dict(
-            [(k, v) for k, v in kwargs.items() if k not in referenced]
-        )
+        params = {k: v for k, v in kwargs.items() if k not in referenced}
         return self._request(
             url,
             params=params,
@@ -495,9 +491,7 @@ class ApiV3(metaclass=abc.ABCMeta):
         """
         referenced = self._extract_referenced_vars(url)
         url = url.format(**kwargs)
-        params = dict(
-            [(k, v) for k, v in kwargs.items() if k not in referenced]
-        )
+        params = {k: v for k, v in kwargs.items() if k not in referenced}
         return self._request(
             url, params=params, method="PUT", check_for_errors=check_for_errors
         )
@@ -521,9 +515,7 @@ class ApiV3(metaclass=abc.ABCMeta):
         """
         referenced = self._extract_referenced_vars(url)
         url = url.format(**kwargs)
-        params = dict(
-            [(k, v) for k, v in kwargs.items() if k not in referenced]
-        )
+        params = {k: v for k, v in kwargs.items() if k not in referenced}
         return self._request(
             url,
             params=params,

--- a/stravalib/strava_model.py
+++ b/stravalib/strava_model.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict, List, Literal, Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -101,7 +101,7 @@ class BaseStream(BaseModel):
 
 
 class CadenceStream(BaseStream):
-    data: Optional[List[int]] = None
+    data: Optional[list[int]] = None
     """
     The sequence of cadence values for this stream, in rotations per minute
     """
@@ -135,7 +135,7 @@ class ClubAthlete(BaseModel):
 
 
 class DistanceStream(BaseStream):
-    data: Optional[List[float]] = None
+    data: Optional[list[float]] = None
     """
     The sequence of distance values for this stream, in meters
     """
@@ -161,7 +161,7 @@ class Fault(BaseModel):
     Encapsulates the errors that may be returned from the API.
     """
 
-    errors: Optional[List[Error]] = None
+    errors: Optional[list[Error]] = None
     """
     The set of specific errors associated with this fault, if any.
     """
@@ -172,7 +172,7 @@ class Fault(BaseModel):
 
 
 class HeartrateStream(BaseStream):
-    data: Optional[List[int]] = None
+    data: Optional[list[int]] = None
     """
     The sequence of heart rate values for this stream, in beats per minute
     """
@@ -183,14 +183,14 @@ class LatLng(BaseModel):
     A pair of latitude/longitude coordinates, represented as an array of 2 floating point numbers.
     """
 
-    __root__: List[float] = Field(..., max_items=2, min_items=2)
+    __root__: list[float] = Field(..., max_items=2, min_items=2)
     """
     A pair of latitude/longitude coordinates, represented as an array of 2 floating point numbers.
     """
 
 
 class LatLngStream(BaseStream):
-    data: Optional[List[LatLng]] = None
+    data: Optional[list[LatLng]] = None
     """
     The sequence of lat/long values for this stream
     """
@@ -241,7 +241,7 @@ class MetaClub(BaseModel):
 
 
 class MovingStream(BaseStream):
-    data: Optional[List[bool]] = None
+    data: Optional[list[bool]] = None
     """
     The sequence of moving values for this stream, as boolean values
     """
@@ -251,7 +251,7 @@ class Primary(BaseModel):
     id: Optional[int] = None
     source: Optional[int] = None
     unique_id: Optional[str] = None
-    urls: Optional[Dict[str, str]] = None
+    urls: Optional[dict[str, str]] = None
 
 
 class PhotosSummary(BaseModel):
@@ -278,21 +278,21 @@ class PolylineMap(BaseModel):
 
 
 class PowerStream(BaseStream):
-    data: Optional[List[int]] = None
+    data: Optional[list[int]] = None
     """
     The sequence of power values for this stream, in watts
     """
 
 
 class SmoothGradeStream(BaseStream):
-    data: Optional[List[float]] = None
+    data: Optional[list[float]] = None
     """
     The sequence of grade values for this stream, as percents of a grade
     """
 
 
 class SmoothVelocityStream(BaseStream):
-    data: Optional[List[float]] = None
+    data: Optional[list[float]] = None
     """
     The sequence of velocity values for this stream, in meters per second
     """
@@ -614,7 +614,7 @@ class SummaryAthlete(MetaAthlete):
 
 
 class SummaryClub(MetaClub):
-    activity_types: Optional[List[ActivityType]] = None
+    activity_types: Optional[list[ActivityType]] = None
     """
     The activity types that count for a club. This takes precedence over sport_type.
     """
@@ -744,14 +744,14 @@ class SummarySegmentEffort(BaseModel):
 
 
 class TemperatureStream(BaseStream):
-    data: Optional[List[int]] = None
+    data: Optional[list[int]] = None
     """
     The sequence of temperature values for this stream, in celsius degrees
     """
 
 
 class TimeStream(BaseStream):
-    data: Optional[List[int]] = None
+    data: Optional[list[int]] = None
     """
     The sequence of time values for this stream, in seconds
     """
@@ -828,7 +828,7 @@ class ZoneRange(BaseModel):
 
 
 class ZoneRanges(BaseModel):
-    __root__: List[ZoneRange]
+    __root__: list[ZoneRange]
 
 
 class ActivityStats(BaseModel):
@@ -883,7 +883,7 @@ class ActivityStats(BaseModel):
 
 
 class AltitudeStream(BaseStream):
-    data: Optional[List[float]] = None
+    data: Optional[list[float]] = None
     """
     The sequence of altitude values for this stream, in meters
     """
@@ -963,11 +963,11 @@ class Comment(BaseModel):
 
 
 class DetailedAthlete(SummaryAthlete):
-    bikes: Optional[List[SummaryGear]] = None
+    bikes: Optional[list[SummaryGear]] = None
     """
     The athlete's bikes.
     """
-    clubs: Optional[List[SummaryClub]] = None
+    clubs: Optional[list[SummaryClub]] = None
     """
     The athlete's clubs.
     """
@@ -987,7 +987,7 @@ class DetailedAthlete(SummaryAthlete):
     """
     The athlete's preferred unit system.
     """
-    shoes: Optional[List[SummaryGear]] = None
+    shoes: Optional[list[SummaryGear]] = None
     """
     The athlete's shoes.
     """
@@ -1325,7 +1325,7 @@ class DetailedSegmentEffort(SummarySegmentEffort):
 
 
 class ExplorerResponse(BaseModel):
-    segments: Optional[List[ExplorerSegment]] = None
+    segments: Optional[list[ExplorerSegment]] = None
     """
     The set of segments matching an explorer request
     """
@@ -1370,7 +1370,7 @@ class Route(BaseModel):
     """
     Whether this route is private
     """
-    segments: Optional[List[SummarySegment]] = None
+    segments: Optional[list[SummarySegment]] = None
     """
     The segments traversed by this route
     """
@@ -1401,7 +1401,7 @@ class TimedZoneDistribution(BaseModel):
     Stores the exclusive ranges representing zones and the time spent in each.
     """
 
-    __root__: List[TimedZoneRange]
+    __root__: list[TimedZoneRange]
     """
     Stores the exclusive ranges representing zones and the time spent in each.
     """
@@ -1418,7 +1418,7 @@ class ActivityZone(BaseModel):
 
 
 class DetailedActivity(SummaryActivity):
-    best_efforts: Optional[List[DetailedSegmentEffort]] = None
+    best_efforts: Optional[list[DetailedSegmentEffort]] = None
     calories: Optional[float] = None
     """
     The number of kilocalories consumed during this activity
@@ -1436,14 +1436,14 @@ class DetailedActivity(SummaryActivity):
     The token used to embed a Strava activity
     """
     gear: Optional[SummaryGear] = None
-    laps: Optional[List[Lap]] = None
+    laps: Optional[list[Lap]] = None
     photos: Optional[PhotosSummary] = None
-    segment_efforts: Optional[List[DetailedSegmentEffort]] = None
-    splits_metric: Optional[List[Split]] = None
+    segment_efforts: Optional[list[DetailedSegmentEffort]] = None
+    splits_metric: Optional[list[Split]] = None
     """
     The splits of this activity in metric units (for runs)
     """
-    splits_standard: Optional[List[Split]] = None
+    splits_standard: Optional[list[Split]] = None
     """
     The splits of this activity in imperial units (for runs)
     """

--- a/stravalib/tests/__init__.py
+++ b/stravalib/tests/__init__.py
@@ -16,7 +16,7 @@ RESOURCES_DIR = os.path.join(TESTS_DIR, "resources")
 
 class TestBase(TestCase):
     def setUp(self):
-        super(TestBase, self).setUp()
+        super().setUp()
 
     def tearDown(self):
-        super(TestBase, self).tearDown()
+        super().tearDown()

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -225,7 +225,7 @@ class XRateLimitRule:
     def _check_limit_rates(self, limit: LimitStructure) -> None:
         """Check the current limit rates for API calls."""
         if limit["usage"] >= limit["limit"]:
-            self.log.debug("Rate limit of {0} reached.".format(limit["limit"]))
+            self.log.debug("Rate limit of {} reached.".format(limit["limit"]))
             limit["lastExceeded"] = datetime.now()
             self._raise_rate_limit_exception(limit["limit"], limit["time"])
 
@@ -236,7 +236,7 @@ class XRateLimitRule:
             if delta < limit["time"]:
                 self.limit_time_invalid = limit["time"] - delta
                 self.log.debug(
-                    "Rate limit invalid duration {0} seconds.".format(
+                    "Rate limit invalid duration {} seconds.".format(
                         self.limit_time_invalid
                     )
                 )
@@ -250,8 +250,8 @@ class XRateLimitRule:
         """Raises an error for the user to see they have exceeded API
         request limits"""
         raise exc.RateLimitExceeded(
-            "Rate limit of {0} exceeded. "
-            "Try again in {1} seconds.".format(limit_rate, timeout),
+            "Rate limit of {} exceeded. "
+            "Try again in {} seconds.".format(limit_rate, timeout),
             limit=limit_rate,
             timeout=timeout,
         )
@@ -307,7 +307,7 @@ class SleepingRateLimitRule:
         """
         if priority not in ["low", "medium", "high"]:
             raise ValueError(
-                'Invalid priority "{0}", expecting one of "low", "medium" or "high"'.format(
+                'Invalid priority "{}", expecting one of "low", "medium" or "high"'.format(
                     priority
                 )
             )
@@ -404,7 +404,7 @@ class RateLimitRule:
                 # request?
                 if self.raise_exc:
                     raise exc.RateLimitExceeded(
-                        "Rate limit exceeded (can try again in {0})".format(
+                        "Rate limit exceeded (can try again in {})".format(
                             self.timeframe - delta
                         )
                     )
@@ -414,7 +414,7 @@ class RateLimitRule:
                     td = self.timeframe - delta
                     sleeptime = td.total_seconds()
                     self.log.debug(
-                        "Rate limit triggered; sleeping for {0}".format(
+                        "Rate limit triggered; sleeping for {}".format(
                             sleeptime
                         )
                     )


### PR DESCRIPTION

Remove supports for python 3.8 following discussion on #301

## Description

- Remove python 3.8 support and ci run against that versions
- run pyupgrade for python 3.9+

## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [x] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [x] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.
