### PR TITLE
Replace flake8 and isort by ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,6 @@
 
 ci:
     autofix_prs: false
-    skip: [flake8]
     autofix_commit_msg: |
       '[pre-commit.ci 🤖] Apply code format tools to PR'
     autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
@@ -35,11 +34,12 @@ repos:
       - id: check-case-conflict
       - id: trailing-whitespace
 
-  # Linting: Python code (see the file .flake8)
-  - repo: https://github.com/PyCQA/flake8
-    rev: "6.1.0"
+  # Linting code using ruff
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.286
     hooks:
-      - id: flake8
+    - id: ruff
+      args: [--fix, --exit-non-zero-on-fix]
 
   # Black for auto code formatting
   - repo: https://github.com/psf/black
@@ -49,14 +49,6 @@ repos:
         entry: bash -c 'black "$@"; git add -u' --
         language_version: python3.10
         args: ["--line-length=79"]
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        entry: bash -c 'isort "$@"; git add -u' --
-        files: \.py$
-        args: ["--profile", "black", "--filter-files"]
 
   - repo: https://github.com/adamchainz/blacken-docs
     rev: "1.16.0"

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 - Remove python 3.8 support following NEP-29 (@enadeau, #416)
 - Stravalib now includes types annotation, the package is PEP 561 compatible (@enadeau, #423)
 - Add blacken-docs and codespell to pre-commit & apply on docs (@lwasser, #391)
+- Infra: Replace flake8 and isort by ruff (@enadeau, #430)
 
 ## v1.4
 

--- a/examples/strava-oauth/server.py
+++ b/examples/strava-oauth/server.py
@@ -1,6 +1,5 @@
 #!flask/bin/python
 from flask import Flask, render_template, request, url_for
-
 from stravalib import Client
 
 app = Flask(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,3 +94,13 @@ warn_untyped_fields = true
 
 [tool.codespell]
 skip = './docs/_build, ./build'
+
+[tool.ruff]
+select = [
+    "F", # pyflakes
+    "I", # isort
+]
+ignore = [
+    "F841"
+]
+line-length = 79

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -33,7 +33,12 @@ from typing_extensions import Self
 
 from stravalib import exc, strava_model
 from stravalib import unithelper as uh
-from stravalib.field_conversions import enum_value, enum_values, time_interval, timezone
+from stravalib.field_conversions import (
+    enum_value,
+    enum_values,
+    time_interval,
+    timezone,
+)
 from stravalib.strava_model import (
     ActivityStats,
     ActivityTotal,
@@ -53,9 +58,6 @@ from stravalib.strava_model import (
     PhotosSummary,
     PolylineMap,
     Primary,
-)
-from stravalib.strava_model import Route as RouteStrava
-from stravalib.strava_model import (
     SportType,
     SummaryClub,
     SummaryGear,
@@ -63,6 +65,7 @@ from stravalib.strava_model import (
     SummarySegmentEffort,
     TimedZoneRange,
 )
+from stravalib.strava_model import Route as RouteStrava
 
 if TYPE_CHECKING:
     from stravalib.client import BatchedResultsIterator


### PR DESCRIPTION
closes #427

## Description

Configure ruff like flake8 was and replace it is CI

Also replace isort

## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [x] Other (please describe) Infrastructure change

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [x] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.
