### PR TITLE
FIX: corrects model for ActivityPhoto

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 - Fix: forgot to update model CI build to follow new src layout (@lwasser, #438)
 - Fix: Type annotation on field that are of type timedelta are now correct (@enadeau, #440)
+- Fix: Correct type for ActivityPhoto sizes attribute (@jsamoocha, #444)
 
 ## v1.5
 

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -720,8 +720,7 @@ class ActivityPhoto(BackwardCompatibilityMixin, DeprecatedSerializableMixin):
     created_at_local: Optional[datetime] = None
     location: Optional[LatLon] = None
     urls: Optional[dict[str, str]] = None
-    # TODO - is this a float return?
-    sizes: Optional[dict[str, float]] = None
+    sizes: Optional[dict[str, list[int]]] = None
     post_id: Optional[int] = None
     default_photo: Optional[bool] = None
     source: Optional[int] = None


### PR DESCRIPTION
closes #443

## Description

The `sizes` attribute of the `ActivityPhoto` was incorrect, leading to parsing errors. This is fixed.

## Type of change

Select the statement best describes this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

## Does your PR include tests

- [x] This change doesn't require tests

I didn't add a test as this a an undocumented API method that can change any time.

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.
