### PR TITLE
Fix: codespell ignore resources dir

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,14 +36,14 @@ repos:
 
   # Linting code using ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.287
+    rev: v0.0.292
     hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
 
   # Black for auto code formatting
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
       - id: black
         entry: bash -c 'black "$@"; git add -u' --
@@ -56,7 +56,7 @@ repos:
       - id: blacken-docs
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.5
+    rev: v2.2.6
     hooks:
       - id: codespell
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@
 #
 # - Run on all files:   pre-commit run --all-files
 # - Register git hooks: pre-commit install --install-hooks
+# - Run a specific hook on all files: pre-commit run codespell --all-files
 
 ci:
     autofix_prs: false
@@ -59,5 +60,6 @@ repos:
     rev: v2.2.6
     hooks:
       - id: codespell
+        files: ^.*\.(py|md|rst)$
         additional_dependencies:
           - tomli

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 - Fix: forgot to update model CI build to follow new src layout (@lwasser, #438)
 - Fix: Type annotation on field that are of type timedelta are now correct (@enadeau, #440)
 - Fix: Correct type for ActivityPhoto sizes attribute (@jsamoocha, #444)
+- Fix: codespell config - ignore resources dir in tests (@lwasser, #445)
 
 ## v1.5
 
@@ -253,7 +254,7 @@
 
 ## 0.9.3
 
-- Fix mutable parma defaults in rate-limiter util functions (@hozn, #155)
+- Fix mutable parameter defaults in rate-limiter util functions (@hozn, #155)
 - Add the missing subscription_permissions attr to Athlete (@hozn, #156)
 
 ## 0.9.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,14 +93,12 @@ warn_required_dynamic_aliases = true
 warn_untyped_fields = true
 
 [tool.codespell]
-skip = './docs/_build, ./build'
+skip = './docs/_build, ./build, ./src/stravalib/tests/resources'
 
 [tool.ruff]
 select = [
-    "F", # pyflakes
-    "I", # isort
+  "F", # pyflakes
+  "I", # isort
 ]
-ignore = [
-    "F841"
-]
+ignore = ["F841"]
 line-length = 79


### PR DESCRIPTION
There is no issue for this. I just see that codespell if failing a simple pre-commit update here #442 so i wanted to make a quick fix to it ignored that tests/resources dir. i'm still perplexed as to how it things there is a word in that line of the file.  

## Description

This is just a tiny config change to how codespell runs

## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [x] This is a infrastructure update (docs, ci, etc)
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [x] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.

