### PR TITLE
Fix: minor - remove examples from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include docs *
 recursive-include src/stravalib/tests/ *
 include requirements.txt
+recursive-exclude examples *

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Unreleased
+- Fix: Manifest.in file - remove example dir (@lwasser, #307)
 
 ## v1.6
 


### PR DESCRIPTION
closes #307

## Description

This is a tiny pr that just removes examples from our sdist. i had opened #307 because when i built i was getting funny results in the sdist with all of the git history there. i'm no longer seeing that behavior so i just am making a tiny cleanup PR and we can then remove another issue from our issue tracker! 

## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [x] This is a infrastructure update (docs, ci, etc)
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [x] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.