### PR TITLE
Fix: add contributing docs to top bar nav in docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Change Log
-Fix: Docs - add contributing section to top bar for easier discovery and a few small syntax fixes in the docs (@lwasser)
 
 ## Unreleased
+Fix: Docs - add contributing section to top bar for easier discovery and a few small syntax fixes in the docs (@lwasser)
 
 ## v1.6
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Change Log
+Fix: Docs - add contributing section to top bar for easier discovery and a few small syntax fixes in the docs (@lwasser)
 
 ## Unreleased
 

--- a/docs/contributing/how-to-contribute.md
+++ b/docs/contributing/how-to-contribute.md
@@ -1,3 +1,2 @@
 
-
 ```{include} ../../CONTRIBUTING.md

--- a/docs/contributing/intro.md
+++ b/docs/contributing/intro.md
@@ -1,0 +1,73 @@
+# Contribute to stravalib
+
+We welcome contributions of all kinds to stravalib! Below are
+some resources to help you get started.
+
+
+::::{grid} 1 1 1 2
+:class-container: text-center
+:gutter: 3
+
+:::{grid-item-card}
+:link: how-to-contribute
+:link-type: doc
+
+✨ **Contributing Guide** ✨
+^^^
+
+Contributing guidelines for stravalib.
+:::
+
+:::{grid-item-card}
+:link: development-guide
+:link-type: doc
+
+✨ **Development Guide** ✨
+^^^
+
+Learn about our development infrastructure and workflows.
+:::
+
+:::{grid-item-card}
+:link: build-release-guide
+:link-type: doc
+
+✨ **Build & Release Guide** ✨
+^^^
+Learn about our build and release workflow. We use version control based versioning.
+:::
+
+
+:::{grid-item-card}
+:link: resources-for-new-contributors
+:link-type: doc
+
+✨ **Contributor Resources** ✨
+^^^
+If you are new to contributing to open source software, these resources will help you get started.
+:::
+
+
+:::{grid-item-card}
+:link: documentation-changelog
+:link-type: doc
+
+✨ **Change Log** ✨
+^^^
+View the history of changes and contributor history for stravalib.
+:::
+::::
+
+
+
+:::{toctree}
+:hidden:
+:caption: Contributing
+:maxdepth: 2
+
+Contributing Guide <../contributing/how-to-contribute>
+Development Guide <../contributing/development-guide>
+Build & Release Guide <../contributing/build-release-guide>
+New Contributor Resources <../contributing/resources-for-new-contributors>
+Change Log <../contributing/documentation-changelog>
+:::

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -12,17 +12,6 @@ Athletes <athletes>
 
 ```
 
-```{toctree}
-:hidden:
-:caption: Contributing
-:maxdepth: 2
-
-Contributing Guide <../contributing/how-to-contribute>
-Development Guide <../contributing/development-guide>
-Build & Release Guide <../contributing/build-release-guide>
-New Contributor Resources <../contributing/resources-for-new-contributors>
-Change Log <../contributing/documentation-changelog>
-```
 
 ## Install stravalib
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -106,3 +106,12 @@ Get Started <get-started/index>
 
 Code/API Reference <reference>
 ```
+
+
+:::{toctree}
+:hidden:
+:caption: Contribute
+:maxdepth: 2
+
+Contribute <contributing/intro.md>
+:::

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -437,7 +437,7 @@ class Client:
 
         Returns
         -------
-        py:class:`stravalib.model.AthleteStats`
+        :class:`stravalib.model.AthleteStats`
             A model containing the Stats
 
         """
@@ -458,7 +458,7 @@ class Client:
 
         Returns
         -------
-        py:class:`list`
+        :class:`list`
             A list of :class:`stravalib.model.Club`
 
         """
@@ -973,7 +973,7 @@ class Client:
 
         Returns
         -------
-        py:class:`list`
+        :class:`list`
             A list of :class:`stravalib.model.BaseActivityZone` objects.
 
         """
@@ -1395,7 +1395,7 @@ class Client:
 
         Returns
         -------
-        py:class:`list`
+        :class:`list`
             An list of :class:`stravalib.model.Segment`.
 
         """
@@ -1544,18 +1544,20 @@ class Client:
             Indicates desired number of data points. 'low' (100), 'medium'
             (1000) or 'high' (10000).
             .. deprecated::
+
                 This param is not officially supported by the Strava API and
                 may be removed in the future.
         series_type : str, optional
             Relevant only if using resolution either 'time' or 'distance'.
             Used to index the streams if the stream is being reduced.
             .. deprecated::
+
                 This param is not officially supported by the Strava API and may be
                 removed in the future.
 
         Returns
         -------
-        py:class:`dict`
+        :class:`dict`
             A dictionary of :class:`stravalib.model.Stream` from the activity
         """
         return self._get_streams(
@@ -1611,7 +1613,7 @@ class Client:
 
         Returns
         -------
-        py:class:`dict`
+        :class:`dict`
             An dictionary of :class:`stravalib.model.Stream` from the effort.
 
         """
@@ -1629,7 +1631,7 @@ class Client:
         resolution: Literal["low", "medium", "high"] | None = None,
         series_type: Literal["time", "distance"] | None = None,
     ) -> dict[StreamType, model.Stream]:
-        """Returns an streams for a segment.
+        """Returns streams for a segment.
 
         https://developers.strava.com/docs/reference/#api-Streams-getSegmentStreams
 
@@ -1654,18 +1656,20 @@ class Client:
             Indicates desired number of data points. 'low' (100), 'medium'
             (1000) or 'high' (10000).
             .. deprecated::
+
                 This param is not officially supported by the Strava API and may be
                 removed in the future.
         series_type : str, optional
             Relevant only if using resolution either 'time' or 'distance'.
             Used to index the streams if the stream is being reduced.
             .. deprecated::
+
                 This param is not officially supported by the Strava API and may be
                 removed in the future.
 
         Returns
         -------
-        py:class:`dict`
+        :class:`dict`
             An dictionary of :class:`stravalib.model.Stream` from the effort.
 
         """
@@ -1751,7 +1755,7 @@ class Client:
 
         Returns
         -------
-        py:class:`dict`
+        :class:`dict`
             A dictionary of :class:`stravalib.model.Stream` from the route.
 
         """
@@ -2118,7 +2122,7 @@ class ActivityUploader:
 
         Parameters
         ----------
-        response : py:class:`dict`
+        response : :class:`dict`
             The response object (dict).
         raise_exc : bool
 


### PR DESCRIPTION
## Description

when i tried to make the release i had to dig around for our contributing docs. it made more sense to add them to the top header of our documentation. In rebuilding i noticed some syntax errors in the client.py file so i fixed those as well so things render properly and don't throw sphinx warnings. 

## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This is a documentation update
- [ ] This is a infrastructure update (docs, ci, etc)
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [x] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.

