### PR TITLE
Remove: unsupported delete_activity method

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 - Fix: Docs - add contributing section to top bar for easier discovery and a few small syntax fixes in the docs (@lwasser)
 - Fix: Manifest.in file - remove example dir (@lwasser, #307)
 - Fix: Codecov report wasn't generating correctly (@lwasser, #469)
+- Remove: `client.delete_activity` method is no longer supported by Strava (@lwasser, #238)
 
 ## v1.6
 

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -944,19 +944,6 @@ class Client:
 
         return ActivityUploader(self, response=initial_response)
 
-    def delete_activity(self, activity_id: int) -> None:
-        """Deletes the specified activity.
-
-        https://developers.strava.com/docs/reference/#api-Activities
-
-        Parameters
-        ----------
-        activity_id : int
-            The activity to delete.
-
-        """
-        self.protocol.delete("/activities/{id}", id=activity_id)
-
     def get_activity_zones(
         self, activity_id: int
     ) -> list[model.BaseActivityZone]:


### PR DESCRIPTION
closes #238

## Description

This is a simple pr that removes a method that was targetting a now unsupported endpoint in the strava API. 

## Type of change

Select the statement best describes this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [ ] This is a infrastructure update (docs, ci, etc)
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [x] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.
 
 please note that i did have a look at the tests but didn't find any relevant to this removal. now let's see if i broke anything given that is what i am best at. 