### PR TITLE
Remove: deserialize method in favor of pydantic.parse_obj()

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 - Fix: Fixes the Strava API update bot (@jsamoocha, #477)
 - Fix: Cleanup dependencies to only use pyproject toml (@lwasser, #466)
 - Add: Strava API change - Route objects have a new waypoints attribute (@bot, #480)
+- Remove: Deprecated deserialize method from deprecated mixin (@lwasser, #358)
 
 ## v1.6
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@
 - Fix: Fixes the Strava API update bot (@jsamoocha, #477)
 - Fix: Cleanup dependencies to only use pyproject toml (@lwasser, #466)
 - Add: Strava API change - Route objects have a new waypoints attribute (@bot, #480)
-- Remove: Deprecated deserialize method from deprecated mixin (@lwasser, #358)
+- Fix: use parse_obj rather than deserialize internally where possible (@lwasser, #358)
 
 ## v1.6
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -51,7 +51,7 @@ def docs_live(session):
     session.run(*cmd)
 
 
-# Use this for venv envs nox -s test
+# Use this for venv envs nox -s mypy
 @nox.session(python="3.10")
 def mypy(session):
     session.install(".[lint]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ tests = [
   "responses"
 ]
 docs = [
-  "sphinx",
+  "sphinx==7.3.5",
   "pydata-sphinx-theme",
   "autodoc_pydantic",
   "sphinx_remove_toctrees",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,9 +125,9 @@ warn_untyped_fields = true
 skip = './docs/_build, ./build, ./src/stravalib/tests/resources'
 
 [tool.ruff]
-select = [
+lint.select = [
   "F", # pyflakes
   "I", # isort
 ]
-ignore = ["F841"]
+lint.ignore = ["F841"]
 line-length = 79

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -1871,7 +1871,7 @@ class Client:
             The JSON response expected by Strava to the challenge request.
 
         """
-        callback = model.SubscriptionCallback.deserialize(raw)
+        callback = model.SubscriptionCallback.parse_obj(raw)
         callback.validate_token(verify_token)
 
         assert callback.hub_challenge is not None
@@ -1962,8 +1962,7 @@ T = TypeVar("T", bound=BaseModel)
 
 
 class ResultFetcher(Protocol):
-    def __call__(self, *, page: int, per_page: int) -> Iterable[Any]:
-        ...
+    def __call__(self, *, page: int, per_page: int) -> Iterable[Any]: ...
 
 
 class BatchedResultsIterator(Generic[T]):
@@ -2036,16 +2035,9 @@ class BatchedResultsIterator(Generic[T]):
 
         entities = []
         for raw in raw_results:
-            try:
-                new_entity = self.entity.parse_obj(
-                    {**raw, **{"bound_client": self.bind_client}}
-                )
-            except AttributeError:
-                # Entity doesn't have a parse_obj() method, so must be of a
-                # legacy type
-                new_entity = self.entity.deserialize(  # type: ignore[attr-defined]
-                    raw, bind_client=self.bind_client
-                )
+            new_entity = self.entity.parse_obj(
+                {**raw, **{"bound_client": self.bind_client}}
+            )
             entities.append(new_entity)
 
         self._buffer = collections.deque(entities)

--- a/src/stravalib/tests/unit/test_model.py
+++ b/src/stravalib/tests/unit/test_model.py
@@ -29,6 +29,7 @@ from stravalib.unithelper import Quantity, UnitConverter
 
 @pytest.mark.parametrize("model_class,attr,value", ((Club, "name", "foo"),))
 class TestLegacyModelSerialization:
+
     def test_legacy_deserialize(self, model_class, attr, value):
         with pytest.warns(DeprecationWarning):
             model_obj = model_class.deserialize({attr: value})
@@ -347,7 +348,7 @@ class ModelTest(TestBase):
             "aspect_type": "create",
             "event_time": 1297286541,
         }
-        subupd = model.SubscriptionUpdate.deserialize(d)
+        subupd = model.SubscriptionUpdate.parse_obj(d)
         self.assertEqual(
             "2011-02-09 21:22:21",
             subupd.event_time.strftime("%Y-%m-%d %H:%M:%S"),

--- a/src/stravalib/tests/unit/test_model.py
+++ b/src/stravalib/tests/unit/test_model.py
@@ -348,7 +348,7 @@ class ModelTest(TestBase):
             "aspect_type": "create",
             "event_time": 1297286541,
         }
-        subupd = model.SubscriptionUpdate.parse_obj(d)
+        subupd = model.SubscriptionUpdate.deserialize(d)
         self.assertEqual(
             "2011-02-09 21:22:21",
             subupd.event_time.strftime("%Y-%m-%d %H:%M:%S"),


### PR DESCRIPTION
closes #358

## Description

This removes the deserialize method and replaces calls to is with pydantic.parse_obj. It also cleans up the tests accordingly.

## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [ ] This is a infrastructure update (docs, ci, etc)
- [x] Other (please describe) this is a deprecation / removal of deprecated features.

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [x] Yes no NEW tests but i cleaned up the tests accordingly
- [ ] No, i'd like some help with tests
- [ ] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.

