### PR TITLE
Fix: update docs around python support

### DIFF
--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -99,6 +99,13 @@ to Strava and handling the received responses (including rate limiting).
 It is used by methods in `client.py` to de-serialize raw response data into
 the domain entities in `model.py`.
 
+## Python support
+We loosely follow the [Numpy guidelines defined in NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html)
+for Python version support. However, in some cases we may decide to
+support older versions of Python given visible community demand for
+such support.
+
+
 ## Code style, linting & typing
 
 We use the following tools to ensure consistent code format that follows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ tests = [
   "responses"
 ]
 docs = [
-  "sphinx==7.3.5",
+  "sphinx",
   "pydata-sphinx-theme",
   "autodoc_pydantic",
   "sphinx_remove_toctrees",


### PR DESCRIPTION
closes #254 

This is a TINY pr that will finish off #254 where we discussed when we drop versions of Python that we support. 
 
## Description

Does anyone have opposition to us dropping Python 3.9 at this point? 
The specific guidelines relate [to this spec](https://scientific-python.org/specs/spec-0000/)
which suggests supporting versions of Python for up to 3 years post release. 

## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This is a documentation update
- [ ] This is a infrastructure update (docs, ci, etc)
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [x] This change doesn't require tests

## Did you include your contribution to the change log?

- [ ] Yes, `changelog.md` is up-to-date.

i didn't update the changelog for this either as it's minor. but if we drop 3.9 then i will refer to this documentation change in that pr via a changelog update. 
