### PR TITLE
Add/Remove: Add support for python 3.12 and drop 3.9

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -10,7 +10,7 @@ jobs:
   build-doc:
     runs-on: ubuntu-latest
     env:
-      PYTHON-VERSION: "3.10"
+      PYTHON-VERSION: "3.11"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
         run: |
           nox -s tests-${{ matrix.python-version }}
       - name: Upload coverage to Codecov
-        if: ${{ matrix.os == 'ubuntu-latest' &&  matrix.python-version == '3.10'}}
+        if: ${{ matrix.os == 'ubuntu-latest' &&  matrix.python-version == '3.11'}}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/push-pypi.yml
+++ b/.github/workflows/push-pypi.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |
@@ -40,17 +40,6 @@ jobs:
 
       - name: Check the archives
         run: twine check dist/*
-
-      - name: Publish package on test PyPI on merge
-        # Test push to test pypi on merge to main
-        if: github.event_name == 'push'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-          # Allow existing releases on test PyPI without errors.
-          # NOT TO BE USED in PyPI!
-          skip_existing: true
 
       - name: Publish package to PyPI
         # Only publish to real PyPI on release

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## Unreleased
-
+- Remove/Add: Drop Python 3.9, add Python 3.12 (@lwasser, #487)
 - Remove: functional test suite from stravalib (@lwasser, #457)
 - Fix: Docs - add contributing section to top bar for easier discovery and a few small syntax fixes in the docs (@lwasser)
 - Fix: Manifest.in file - remove example dir (@lwasser, #307)

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,7 @@ nox.options.reuse_existing_virtualenvs = True
 
 
 # Use this for venv envs nox -s test
-@nox.session(python=["3.9", "3.10", "3.11"])
+@nox.session(python=["3.10", "3.11", "3.12"])
 def tests(session):
     """Install requirements in a venv and run tests."""
     session.install(".[tests]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,22 +32,21 @@ maintainers = [
   { name = "Yihong" },
   { name = "Émile Nadeau" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python",
   "Intended Audience :: Science/Research",
   "Intended Audience :: Developers",
-  # Because license is listed below does it need to be here too?
   "License :: OSI Approved :: Apache Software License",
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Topic :: Scientific/Engineering",
   "Topic :: Software Development :: Libraries",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 
 dependencies = ["pint", "pytz", "arrow", "requests", "pydantic<2.0"]


### PR DESCRIPTION
closes #487 


## Description

This drops Python 3.9 from all builds and adds 3.12. 

## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [ ] This is a infrastructure update (docs, ci, etc)
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [x] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.

