### PR TITLE
Fix: add tests for datetime function

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## Unreleased
+- Add: test for naive datetime (Pydantic method deprecated) (@lwasser)
+
 
 ## v1.7
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## Unreleased
-- Add: test for naive datetime (Pydantic method deprecated) (@lwasser)
+- Add: test for naive datetime (Pydantic method deprecated) (#491, @lwasser)
 
 
 ## v1.7

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -174,8 +174,8 @@ AllDateTypes = Union[datetime, str, bytes, int, float]
 
 def naive_datetime(value: Optional[AllDateTypes]) -> Optional[datetime]:
     """Utility helper that parses a datetime value provided in
-    JSON, string, int or other formats and returns a datetime.datetime
-    object
+    JSON, string, int or other formats and returns a `datetime.datetime`
+    object.
 
     Parameters
     ----------
@@ -187,8 +187,15 @@ def naive_datetime(value: Optional[AllDateTypes]) -> Optional[datetime]:
     -------
     datetime.datetime
         A datetime object representing the datetime input value.
+
+    Notes
+    -----
+    Valid str, following formats work (from pydantic docs):
+
+    YYYY-MM-DD[T]HH:MM[:SS[.ffffff]][Z or [±]HH[:]MM]
     """
     if value:
+        # TODO: parse_datetime was deprecated in Pydantic 2.0
         dt = parse_datetime(value)
         return dt.replace(tzinfo=None)
     else:

--- a/src/stravalib/tests/unit/test_model.py
+++ b/src/stravalib/tests/unit/test_model.py
@@ -357,12 +357,10 @@ class ModelTest(TestBase):
         )
 
 
-from datetime import datetime
-
 # Creating a timezone-aware datetime object
 dt = datetime(2022, 4, 28, 12, 0, tzinfo=timezone.utc)
 
-# Converting datetime to POSIX time
+# Convert datetime to POSIX time
 posix_time = int(dt.timestamp())
 
 


### PR DESCRIPTION
There is no open issue for this

## Description

This pr adds tests for the naive datetime function that is now in the model.py file. 
NOTE: We might want to migrate this to our utils in the refactor

I am adding this test because pydantic 2.x drops parse_datetime support. As such we will want to move to a different method for handling date times (possibly dateutils). adding this test now will make that migration easier when we go to implement it.

## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [x] This is a infrastructure update (docs, ci, etc) -- tests
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [x] Yes
- [ ] No, i'd like some help with tests
- [ ] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.

