### PR TITLE
Remove backward compatibility mixin

### DIFF
--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -668,7 +668,7 @@ class ActivityPhoto(BaseModel):
         else:
             photo_type = "(no type)"
             idfield = "id"
-            idval = self.id
+            idval = self.uid
 
         return "<{clz} {type} {idfield}={id}>".format(
             clz=self.__class__.__name__,
@@ -792,7 +792,7 @@ class AthletePrEffort(
     _naive_local = field_validator("start_date_local")(naive_datetime)
 
     @property
-    def elapsed_time(self) -> Optional[timedelta]:
+    def elapsed_time(self) -> Optional[int]:
         """A property that supports backwards compatibility with the
         elapsed_time method used in previous versions of stravalib"""
 

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -31,10 +31,6 @@ from dateutil import parser
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from stravalib import exc, strava_model
-from stravalib import unithelper as uh
-from stravalib.field_conversions import (
-    timezone,
-)
 from stravalib.strava_model import (
     ActivityStats,
     ActivityTotal,
@@ -197,69 +193,6 @@ def check_valid_location(
 AllDateTypes = Union[datetime, str, bytes, int, float]
 
 
-class BackwardCompatibilityMixin:
-    """
-    Mixin that intercepts attribute lookup and raises warnings or modifies
-    return values based on what is defined in the following class attributes:
-
-    * _field_conversions
-
-    Notes
-    ------
-    The class attributes below are not yet implemented:
-    * _deprecated_fields (TODO)
-    * _unsupported_fields (TODO)
-    """
-
-    pass
-
-    def __getattribute__(self, attr: str) -> Any:
-        """A method to retrieve attributes from the object.
-
-        Parameters
-        ----------
-        attr : str
-            The name of the attribute to retrieve.
-
-        Returns
-        -------
-        Any
-            The value of the requested attribute.
-
-        Notes
-        -----
-        This method is called whenever an attribute is accessed on the object.
-        It is used to control attribute retrieval and perform additional
-        actions.
-
-        """
-        value = object.__getattribute__(self, attr)
-        if attr in ["_field_conversions", "bound_client"] or attr.startswith(
-            "_"
-        ):
-            return value
-        try:
-            # This won't return a attribute error if it's none
-            if attr in self._field_conversions:
-                return self._field_conversions[attr](value)
-        except (TypeError, AttributeError):
-            # Handle case where _field_conversions is None or not subscriptable
-            pass
-        try:
-            value.bound_client = self.bound_client
-            return value
-        except (AttributeError, ValueError):
-            pass
-        try:
-            for v in value:
-                v.bound_client = self.bound_client
-            return value
-        except (AttributeError, ValueError, TypeError):
-            # TypeError if v is not iterable
-            pass
-        return value
-
-
 class BoundClientEntity(BaseModel):
     """A class that bounds the Client object to the model."""
 
@@ -323,7 +256,7 @@ class RelaxedSportType(SportType):
         return values
 
 
-class LatLon(LatLng, BackwardCompatibilityMixin):
+class LatLon(LatLng):
     """
     Enables backward compatibility for legacy namedtuple
     """
@@ -381,7 +314,6 @@ class LatLon(LatLng, BackwardCompatibilityMixin):
 
 class Club(
     DetailedClub,
-    BackwardCompatibilityMixin,
     BoundClientEntity,
 ):
     """
@@ -434,12 +366,12 @@ class Club(
         return self.bound_client.get_club_activities(self.id)
 
 
-class Gear(DetailedGear, BackwardCompatibilityMixin):
+class Gear(DetailedGear):
     """
     Represents a piece of gear (equipment) used in physical activities.
     """
 
-    _field_conversions = {"distance": uh.meters}
+    pass
 
 
 class Bike(Gear):
@@ -460,19 +392,14 @@ class Shoe(Gear):
     pass
 
 
-class ActivityTotals(ActivityTotal, BackwardCompatibilityMixin):
+class ActivityTotals(ActivityTotal):
     """An objecting containing a set of total values for an activity including
     elapsed time, moving time, distance and elevation gain."""
 
-    _field_conversions = {
-        "distance": uh.meters,
-        "elevation_gain": uh.meters,
-    }
-    elapsed_time: Optional[timedelta] = None  # type: ignore[assignment]
-    moving_time: Optional[timedelta] = None  # type: ignore[assignment]
+    pass
 
 
-class AthleteStats(ActivityStats, BackwardCompatibilityMixin):
+class AthleteStats(ActivityStats):
     """
     Summary totals for rides, runs and swims, as shown in an athlete's public
     profile. Non-public activities are not counted for these totals.
@@ -489,15 +416,9 @@ class AthleteStats(ActivityStats, BackwardCompatibilityMixin):
     all_run_totals: Optional[ActivityTotals] = None
     all_swim_totals: Optional[ActivityTotals] = None
 
-    _field_conversions = {
-        "biggest_ride_distance": uh.meters,
-        "biggest_climb_elevation_gain": uh.meters,
-    }
-
 
 class Athlete(
     DetailedAthlete,
-    BackwardCompatibilityMixin,
     BoundClientEntity,
 ):
     """Represents high level athlete information including
@@ -698,7 +619,7 @@ class ActivityPhotoMeta(PhotosSummary):
     use_primary_photo: Optional[bool] = None
 
 
-class ActivityPhoto(BaseModel, BackwardCompatibilityMixin):
+class ActivityPhoto(BaseModel):
     """A full photo record attached to an activity.
 
     Notes
@@ -771,7 +692,6 @@ class ActivityKudos(Athlete):
 
 class ActivityLap(
     Lap,
-    BackwardCompatibilityMixin,
     BoundClientEntity,
 ):
     # Field overrides from superclass for type extensions:
@@ -784,15 +704,6 @@ class ActivityLap(
     max_heartrate: Optional[float] = None
     device_watts: Optional[bool] = None
 
-    _field_conversions = {
-        "distance": uh.meters,
-        "total_elevation_gain": uh.meters,
-        "average_speed": uh.meters_per_second,
-        "max_speed": uh.meters_per_second,
-    }
-    elapsed_time: Optional[timedelta] = None  # type: ignore[assignment]
-    moving_time: Optional[timedelta] = None  # type: ignore[assignment]
-
     _naive_local = field_validator("start_date_local")(naive_datetime)
 
 
@@ -804,7 +715,6 @@ class Map(PolylineMap):
 
 class Split(
     strava_model.Split,
-    BackwardCompatibilityMixin,
 ):
     """
     A split -- may be metric or standard units (which has no bearing
@@ -815,19 +725,9 @@ class Split(
     average_heartrate: Optional[float] = None
     average_grade_adjusted_speed: Optional[float] = None
 
-    _field_conversions = {
-        "distance": uh.meters,
-        "elevation_difference": uh.meters,
-        "average_speed": uh.meters_per_second,
-        "average_grade_adjusted_speed": uh.meters_per_second,
-    }
-    elapsed_time: Optional[timedelta] = None  # type: ignore[assignment]
-    moving_time: Optional[timedelta] = None  # type: ignore[assignment]
-
 
 class SegmentExplorerResult(
     ExplorerSegment,
-    BackwardCompatibilityMixin,
     BoundClientEntity,
 ):
     """
@@ -843,8 +743,6 @@ class SegmentExplorerResult(
 
     # Undocumented attributes:
     starred: Optional[bool] = None
-
-    _field_conversions = {"elev_difference", uh.meters, "distance", uh.meters}
 
     _check_latlng = field_validator(
         "start_latlng", "end_latlng", mode="before"
@@ -869,7 +767,6 @@ class SegmentExplorerResult(
 
 class AthleteSegmentStats(
     SummarySegmentEffort,
-    BackwardCompatibilityMixin,
 ):
     """
     A structure being returned for segment stats for current athlete.
@@ -880,28 +777,17 @@ class AthleteSegmentStats(
     pr_elapsed_time: Optional[timedelta] = None
     pr_date: Optional[date] = None
 
-    _field_conversions = {
-        "distance": uh.meters,
-    }
-    elapsed_time: Optional[timedelta] = None  # type: ignore[assignment]
-
     _naive_local = field_validator("start_date_local")(naive_datetime)
 
 
 class AthletePrEffort(
     SummaryPRSegmentEffort,
-    BackwardCompatibilityMixin,
 ):
     # Undocumented attributes:
     distance: Optional[float] = None
     start_date: Optional[datetime] = None
     start_date_local: Optional[datetime] = None
     is_kom: Optional[bool] = None
-
-    _field_conversions = {
-        "distance": uh.meters,
-    }
-    pr_elapsed_time: Optional[timedelta] = None  # type: ignore[assignment]
 
     _naive_local = field_validator("start_date_local")(naive_datetime)
 
@@ -915,7 +801,6 @@ class AthletePrEffort(
 
 class Segment(
     DetailedSegment,
-    BackwardCompatibilityMixin,
     BoundClientEntity,
 ):
     """
@@ -939,13 +824,6 @@ class Segment(
     pr_time: Optional[timedelta] = None
     starred_date: Optional[datetime] = None
     elevation_profile: Optional[str] = None
-
-    _field_conversions = {
-        "distance": uh.meters,
-        "elevation_high": uh.meters,
-        "elevation_low": uh.meters,
-        "total_elevation_gain": uh.meters,
-    }
 
     _latlng_check = field_validator(
         "start_latlng", "end_latlng", mode="before"
@@ -981,7 +859,6 @@ class SegmentEffortAchievement(BaseModel):
 
 class BaseEffort(
     DetailedSegmentEffort,
-    BackwardCompatibilityMixin,
     BoundClientEntity,
 ):
     """
@@ -992,12 +869,6 @@ class BaseEffort(
     segment: Optional[Segment] = None
     activity: Optional[Activity] = None
     athlete: Optional[Athlete] = None
-
-    _field_conversions = {
-        "distance": uh.meters,
-    }
-    moving_time: Optional[timedelta] = None  # type: ignore[assignment]
-    elapsed_time: Optional[timedelta] = None  # type: ignore[assignment]
 
     _naive_local = field_validator("start_date_local")(naive_datetime)
 
@@ -1020,7 +891,6 @@ class SegmentEffort(BaseEffort):
 
 class Activity(
     DetailedActivity,
-    BackwardCompatibilityMixin,
     BoundClientEntity,
 ):
     """
@@ -1075,16 +945,6 @@ class Activity(
     segment_leaderboard_opt_out: Optional[bool] = None
     perceived_exertion: Optional[int] = None
 
-    _field_conversions = {
-        "timezone": timezone,
-        "distance": uh.meters,
-        "total_elevation_gain": uh.meters,
-        "average_speed": uh.meters_per_second,
-        "max_speed": uh.meters_per_second,
-    }
-    moving_time: Optional[timedelta] = None  # type: ignore[assignment]
-    elapsed_time: Optional[timedelta] = None  # type: ignore[assignment]
-
     _latlng_check = field_validator(
         "start_latlng", "end_latlng", mode="before"
     )(check_valid_location)
@@ -1135,8 +995,6 @@ class DistributionBucket(TimedZoneRange):
     return `int` or `float`.
     """
 
-    _field_conversions = {"time": uh.seconds}
-
     # Overrides due to a bug in the Strava API docs
     # Because the created strava_model.py has this typed as int we will need
     # to override these types
@@ -1146,7 +1004,6 @@ class DistributionBucket(TimedZoneRange):
 
 class BaseActivityZone(
     ActivityZone,
-    BackwardCompatibilityMixin,
     BoundClientEntity,
 ):
     """
@@ -1163,7 +1020,7 @@ class BaseActivityZone(
     type: Optional[Literal["heartrate", "power", "pace"]] = None  # type: ignore[assignment]
 
 
-class Stream(BaseStream, BackwardCompatibilityMixin):
+class Stream(BaseStream):
     """
     Stream of readings from the activity, effort or segment.
     """
@@ -1177,7 +1034,6 @@ class Stream(BaseStream, BackwardCompatibilityMixin):
 
 class Route(
     RouteStrava,
-    BackwardCompatibilityMixin,
     BoundClientEntity,
 ):
     """
@@ -1189,10 +1045,8 @@ class Route(
     map: Optional[Map] = None
     segments: Optional[list[Segment]]  # type: ignore[assignment]
 
-    _field_conversions = {"distance": uh.meters, "elevation_gain": uh.meters}
 
-
-class Subscription(BackwardCompatibilityMixin, BoundClientEntity):
+class Subscription(BaseModel):
     """
     Represents a Webhook Event Subscription.
     """
@@ -1210,10 +1064,7 @@ class Subscription(BackwardCompatibilityMixin, BoundClientEntity):
     updated_at: Optional[datetime] = None
 
 
-# Note: the DeprecatedSerializableMixin inherited from BaseModel
-# So we may have to add BaseModel to some of these smaller objects that
-# relied upon the mixin
-class SubscriptionCallback(BaseModel, BackwardCompatibilityMixin):
+class SubscriptionCallback(BaseModel):
     """
     Represents a Webhook Event Subscription Callback.
     """
@@ -1248,7 +1099,7 @@ class SubscriptionCallback(BaseModel, BackwardCompatibilityMixin):
         assert self.hub_verify_token == verify_token
 
 
-class SubscriptionUpdate(BackwardCompatibilityMixin, BoundClientEntity):
+class SubscriptionUpdate(BaseModel):
     """
     Represents a Webhook Event Subscription Update.
     """

--- a/src/stravalib/tests/integration/test_client.py
+++ b/src/stravalib/tests/integration/test_client.py
@@ -7,12 +7,11 @@ import pytest
 import responses
 from responses import matchers
 
-import stravalib.unithelper as uh
 from stravalib.client import ActivityUploader
 from stravalib.exc import AccessUnauthorized, ActivityPhotoUploadFailed
 from stravalib.model import Athlete
 from stravalib.tests import RESOURCES_DIR
-from stravalib.unithelper import UnitConverter, meters, miles
+from stravalib.unithelper import miles
 
 
 @pytest.fixture
@@ -156,7 +155,7 @@ def test_get_activity_laps(mock_strava_api, client):
     )
     laps = list(client.get_activity_laps(42))
     assert len(laps) == 2
-    assert laps[0].distance == meters(1000)
+    assert laps[0].distance == 1000
 
 
 def test_get_club_activities(mock_strava_api, client):
@@ -168,7 +167,7 @@ def test_get_club_activities(mock_strava_api, client):
 
     activities = list(client.get_club_activities(42))
     assert len(activities) == 2
-    assert activities[0].distance == meters(1000)
+    assert activities[0].distance == 1000
 
 
 def test_get_activity_zones(mock_strava_api, client, zone_response):
@@ -783,9 +782,7 @@ def test_get_athlete_stats(
             client.get_athlete_stats(athlete_id)
     else:
         stats = client.get_athlete_stats(athlete_id)
-        assert stats.biggest_ride_distance == UnitConverter("meters")(
-            expected_biggest_ride_distance
-        )
+        assert stats.biggest_ride_distance == expected_biggest_ride_distance
 
 
 def test_get_gear(mock_strava_api, client):
@@ -826,10 +823,10 @@ def test_get_activities_quantity_addition(mock_strava_api, client):
         n_results=2,
     )
     act_list = list(client.get_activities(limit=2))
-    total_d = uh.meters(0)
+    total_d = 0
     total_d += act_list[0].distance
     total_d += act_list[1].distance
-    assert total_d == uh.meters(2000.0)
+    assert total_d == 2000.0
 
 
 def test_get_segment(mock_strava_api, client):


### PR DESCRIPTION
closes #498

## Description

Removes `BackwardCompatibilityMixin` and its related `_field_conversions` model attributes. As a result, all the previously "modified" types that, e.g., returned a pint `Quantity` object instead of a unitless float now return the base type. Later PRs will re-add these customized types but will ensure they match the parent type.

## Type of change

Select the statement best describes this pull request.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Does your PR include tests

- [x] Yes

But the new test is skipped until we implement the new custom types.

## Did you include your contribution to the change log?

Let's add one changelog entry for when the complete `pydantic-v2` branch merges into `main`?
