### PR TITLE
Adds Strava type hierarchy for Activity type

### DIFF
--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -271,7 +271,7 @@ class Client:
         before: datetime | str | None = None,
         after: datetime | str | None = None,
         limit: int | None = None,
-    ) -> BatchedResultsIterator[model.Activity]:
+    ) -> BatchedResultsIterator[model.SummaryActivity]:
         """Get activities for authenticated user sorted by newest first.
 
         https://developers.strava.com/docs/reference/#api-Activities-getLoggedInAthleteActivities
@@ -290,7 +290,7 @@ class Client:
         Returns
         -------
         class:`BatchedResultsIterator`
-            An iterator of :class:`stravalib.model.Activity` objects.
+            An iterator of :class:`stravalib.model.SummaryActivity` objects.
 
         """
 
@@ -302,7 +302,7 @@ class Client:
         )
 
         return BatchedResultsIterator(
-            entity=model.Activity,
+            entity=model.SummaryActivity,
             bind_client=self,
             result_fetcher=result_fetcher,
             limit=limit,

--- a/src/stravalib/tests/integration/test_client.py
+++ b/src/stravalib/tests/integration/test_client.py
@@ -10,6 +10,7 @@ from responses import matchers
 from stravalib.client import ActivityUploader
 from stravalib.exc import AccessUnauthorized, ActivityPhotoUploadFailed
 from stravalib.model import Athlete
+from stravalib.strava_model import SummaryActivity
 from stravalib.tests import RESOURCES_DIR
 from stravalib.unithelper import miles
 
@@ -813,6 +814,7 @@ def test_get_activities(
     activity_list = list(client.get_activities(**kwargs))
     assert len(activity_list) == expected_n_activities
     if expected_n_activities > 0:
+        assert isinstance(activity_list[0], SummaryActivity)
         assert activity_list[0].name == "test_activity"
 
 


### PR DESCRIPTION
This is a tiny PR to show how making the Strava type hierarchy explicit in our client responses can improve type-checking accuracy and prevent user confusion (see #494).

This approach can be used to resolve #499.