### PR TITLE
Fix: fix return types - athlete clubs endpoint

### DIFF
--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -468,8 +468,6 @@ class Client:
 
         """
 
-        # TODO: This should return a BatchedResultsIterator or otherwise at
-        # most 30 clubs are returned!
         result_fetcher = functools.partial(self.protocol.get, "/athlete/clubs")
         # club_structs = self.protocol.get("/athlete/clubs")
 

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -469,8 +469,6 @@ class Client:
         """
 
         result_fetcher = functools.partial(self.protocol.get, "/athlete/clubs")
-        # club_structs = self.protocol.get("/athlete/clubs")
-
         return BatchedResultsIterator(
             entity=model.SummaryClub,
             bind_client=self,

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -451,7 +451,6 @@ class Client:
 
         return model.AthleteStats.model_validate(raw)
 
-    # TODO - create model.summaryClub
     def get_athlete_clubs(
         self, limit: int | None = None
     ) -> BatchedResultsIterator[model.SummaryClub]:

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -451,7 +451,7 @@ class Client:
 
         return model.AthleteStats.model_validate(raw)
 
-    def get_athlete_clubs(self) -> list[model.Club]:
+    def get_athlete_clubs(self) -> list[model.SummaryClub]:
         """List the clubs for the currently authenticated athlete.
 
         https://developers.strava.com/docs/reference/#api-Clubs-getLoggedInAthleteClubs
@@ -468,7 +468,7 @@ class Client:
         # most 30 clubs are returned!
         club_structs = self.protocol.get("/athlete/clubs")
         return [
-            model.Club.model_validate({**raw, **{"bound_client": self}})
+            model.SummaryClub.model_validate({**raw, **{"bound_client": self}})
             for raw in club_structs
         ]
 

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -47,7 +47,6 @@ from stravalib.strava_model import (
     PolylineMap,
     Primary,
     SportType,
-    SummaryClub,
     SummaryGear,
     SummaryPRSegmentEffort,
     SummarySegmentEffort,
@@ -363,6 +362,16 @@ class Club(
         """
         assert self.bound_client is not None, "Bound client is not set."
         return self.bound_client.get_club_activities(self.id)
+
+
+class SummaryClub(strava_model.SummaryClub):
+    """Represents the summaryClub object with undocumented attributes
+    included
+
+    """
+
+    # Undocumented attributes
+    profile: Optional[str] = None
 
 
 class Gear(DetailedGear):

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -325,7 +325,11 @@ class Club(
     Notes
     -----
     Clubs are the only object that can have multiple valid
-    `activity_types`. Activities only have one
+    `activity_types`. Activities only have one.
+
+    Endpoint docs are found here:
+    https://developers.strava.com/docs/reference/#api-models-SummaryClub
+
 
     """
 

--- a/src/stravalib/strava_model.py
+++ b/src/stravalib/strava_model.py
@@ -726,8 +726,6 @@ class SummaryAthlete(MetaAthlete):
 
 
 class SummaryClub(MetaClub):
-    # Activity types is listed in the spec but not shown in the response
-    # https://developers.strava.com/docs/reference/#api-Clubs-getLoggedInAthleteClubs
     activity_types: Optional[list[ActivityType]] = None
     """
     The activity types that count for a club. This takes precedence over sport_type.
@@ -782,9 +780,6 @@ class SummaryClub(MetaClub):
     """
     Whether the club is verified or not.
     """
-
-    # Undocumented attributes
-    profile: Optional[str] = None
 
 
 class SummaryGear(BaseModel):

--- a/src/stravalib/strava_model.py
+++ b/src/stravalib/strava_model.py
@@ -726,6 +726,8 @@ class SummaryAthlete(MetaAthlete):
 
 
 class SummaryClub(MetaClub):
+    # Activity types is listed in the spec but not shown in the response
+    # https://developers.strava.com/docs/reference/#api-Clubs-getLoggedInAthleteClubs
     activity_types: Optional[list[ActivityType]] = None
     """
     The activity types that count for a club. This takes precedence over sport_type.
@@ -780,6 +782,9 @@ class SummaryClub(MetaClub):
     """
     Whether the club is verified or not.
     """
+
+    # Undocumented attributes
+    profile: Optional[str] = None
 
 
 class SummaryGear(BaseModel):

--- a/src/stravalib/tests/integration/test_client.py
+++ b/src/stravalib/tests/integration/test_client.py
@@ -733,14 +733,19 @@ def test_get_club(mock_strava_api, client):
 
 
 @pytest.mark.parametrize("n_clubs", (0, 2))
-def test_get_athlete_clubs(mock_strava_api, client, n_clubs):
+def test_get_athlete_clubs_iterator(mock_strava_api, client, n_clubs):
+    """Test that athlete clubs returns the correct
+    number of clubs"""
+
+    # Create a mock instance with the club name update to my club
     mock_strava_api.get(
-        "/athlete/clubs", response_update={"name": "foo"}, n_results=n_clubs
+        "/athlete/clubs", response_update={"name": "myclub"}, n_results=n_clubs
     )
-    clubs = client.get_athlete_clubs()
+    # Convert iterator to list
+    clubs = list(client.get_athlete_clubs())
     assert len(clubs) == n_clubs
     if clubs:
-        assert clubs[0].name == "foo"
+        assert clubs[0].name == "myclub"
 
 
 @pytest.mark.parametrize("n_members", (0, 2))


### PR DESCRIPTION
This adjusts the return types for the athlete/clubs endpoint. It also updates a test and modifies the return object type to be an iterator vs a list. 

#506 



