### PR TITLE
Add: correct type returns following clubs/{id}  & clubs/{id}/activities spec

### DIFF
--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -512,7 +512,7 @@ class Client:
         """
         self.protocol.post("clubs/{id}/leave", id=club_id)
 
-    def get_club(self, club_id: int) -> model.Club:
+    def get_club(self, club_id: int) -> model.DetailedClub:
         """Return a specific club object.
 
         https://developers.strava.com/docs/reference/#api-Clubs-getClubById
@@ -524,11 +524,13 @@ class Client:
 
         Returns
         -------
-        class: `model.Club` object containing the club data.
+        class: `model.DetailedClub` object containing the club data.
 
         """
         raw = self.protocol.get("/clubs/{id}", id=club_id)
-        return model.Club.model_validate({**raw, **{"bound_client": self}})
+        return model.DetailedClub.model_validate(
+            {**raw, **{"bound_client": self}}
+        )
 
     def get_club_members(
         self, club_id: int, limit: int | None = None

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -565,7 +565,7 @@ class Client:
 
     def get_club_activities(
         self, club_id: int, limit: int | None = None
-    ) -> BatchedResultsIterator[model.Activity]:
+    ) -> BatchedResultsIterator[model.ClubActivity]:
         """Gets the activities associated with specified club.
 
         https://developers.strava.com/docs/reference/#api-Clubs-getClubActivitiesById
@@ -588,7 +588,7 @@ class Client:
         )
 
         return BatchedResultsIterator(
-            entity=model.Activity,
+            entity=model.ClubActivity,
             bind_client=self,
             result_fetcher=result_fetcher,
             limit=limit,

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -51,6 +51,7 @@ from stravalib.strava_model import (
     PolylineMap,
     Primary,
     SportType,
+    SummaryAthlete,
     SummaryGear,
     TimedZoneRange,
 )
@@ -421,11 +422,7 @@ class MetaAthlete(strava_model.MetaAthlete, BoundClientEntity):
     pass
 
 
-class SummaryAthlete(MetaAthlete, strava_model.SummaryAthlete):
-    pass
-
-
-class Athlete(SummaryAthlete, strava_model.DetailedAthlete):
+class Athlete(strava_model.DetailedAthlete):
     """Represents high level athlete information including
     their name, email, clubs they belong to, bikes, shoes, etc.
 
@@ -957,15 +954,6 @@ class Activity(
     _naive_local = field_validator("start_date_local")(naive_datetime)
 
 
-class ClubAthlete(strava_model.MetaAthlete):
-    """This is an object that contains the items returned via
-    the actual strava api"""
-
-    resource_state: int
-    firstname: Optional[str]
-    lastname: Optional[str]
-
-
 class ClubActivity(strava_model.ClubActivity):
     """Represents an activity returned from a club.
 
@@ -973,13 +961,14 @@ class ClubActivity(strava_model.ClubActivity):
     -----
     The actual strava API specification suggests that this should
     return a MetaAthlete Object for the activities' athlete information.
-    However, that is actually returned is resource_state, first name and
+    However, while that object should return the correct values, it is missing what is
+     actually returned returns is actually returned is resource_state, first name and
     last initial. So this object doesn't match the spec but does match the
     actual return.
     """
 
     # Spec calls for a return of a metaAthlete object (which only has id in it)
-    athlete: Optional[ClubAthlete] = None
+    athlete: Optional[strava_model.ClubAthlete] = None
 
     pass
 

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -962,7 +962,7 @@ class ClubActivity(strava_model.ClubActivity):
     The actual strava API specification suggests that this should
     return a MetaAthlete Object for the activities' athlete information.
     However, while that object should return the correct values, it is missing what is
-     actually returned returns is actually returned is resource_state, first name and
+     actually returned, i.e., resource_state, first name and
     last initial. So this object doesn't match the spec but does match the
     actual return.
     """

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -43,7 +43,6 @@ from stravalib.strava_model import (
     ActivityZone,
     BaseStream,
     Comment,
-    DetailedClub,
     DetailedGear,
     ExplorerSegment,
     Lap,
@@ -303,10 +302,11 @@ class LatLon(LatLng):
         return self.root[1]
 
 
-class Club(
-    DetailedClub,
-    BoundClientEntity,
-):
+class MetaClub(strava_model.MetaClub, BoundClientEntity):
+    pass
+
+
+class SummaryClub(MetaClub, strava_model.SummaryClub):
     """
     Represents a single club with detailed information about the club including
     club name, id, location, activity types, etc.
@@ -314,8 +314,6 @@ class Club(
     See Also
     --------
     DetailedClub : A class representing a club's detailed information.
-    BackwardCompatibilityMixin : A mixin to provide backward compatibility with
-        legacy BaseDetailedEntity.
     BoundClientEntity : A mixin to bind the club with a Strava API client.
 
     Notes
@@ -333,6 +331,14 @@ class Club(
     profile: Optional[str] = None
     description: Optional[str] = None
     club_type: Optional[str] = None
+    activity_types_icon: Optional[str] = None
+    dimensions: Optional[list[str]] = None
+    localized_sport_type: Optional[str] = None
+    # These items BELOW should come from detailed club but
+    # they are returned in the clubs/{id} endpoint. why?
+    # membership: Optional[bool] = None
+    # admin: Optional[bool] = None
+    # owner: Optional[bool] = None
 
     @lazy_property
     def members(self) -> BatchedResultsIterator[Athlete]:
@@ -361,14 +367,8 @@ class Club(
         return self.bound_client.get_club_activities(self.id)
 
 
-class SummaryClub(strava_model.SummaryClub):
-    """Represents the summaryClub object with undocumented attributes
-    included
-
-    """
-
-    # Undocumented attributes
-    profile: Optional[str] = None
+class DetailedClub(SummaryClub, strava_model.DetailedClub):
+    pass
 
 
 class Gear(DetailedGear):

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -334,11 +334,6 @@ class SummaryClub(MetaClub, strava_model.SummaryClub):
     activity_types_icon: Optional[str] = None
     dimensions: Optional[list[str]] = None
     localized_sport_type: Optional[str] = None
-    # These items BELOW should come from detailed club but
-    # they are returned in the clubs/{id} endpoint. why?
-    # membership: Optional[bool] = None
-    # admin: Optional[bool] = None
-    # owner: Optional[bool] = None
 
     @lazy_property
     def members(self) -> BatchedResultsIterator[Athlete]:

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -903,6 +903,7 @@ class SummaryActivity(MetaActivity, strava_model.SummaryActivity):
     )(check_valid_location)
 
 
+# TODO: should this be named Detailed Activity?
 class Activity(
     SummaryActivity,
     strava_model.DetailedActivity,
@@ -954,6 +955,33 @@ class Activity(
     perceived_exertion: Optional[int] = None
 
     _naive_local = field_validator("start_date_local")(naive_datetime)
+
+
+class ClubAthlete(strava_model.MetaAthlete):
+    """This is an object that contains the items returned via
+    the actual strava api"""
+
+    resource_state: int
+    firstname: Optional[str]
+    lastname: Optional[str]
+
+
+class ClubActivity(strava_model.ClubActivity):
+    """Represents an activity returned from a club.
+
+    Notes
+    -----
+    The actual strava API specification suggests that this should
+    return a MetaAthlete Object for the activities' athlete information.
+    However, that is actually returned is resource_state, first name and
+    last initial. So this object doesn't match the spec but does match the
+    actual return.
+    """
+
+    # Spec calls for a return of a metaAthlete object (which only has id in it)
+    athlete: Optional[ClubAthlete] = None
+
+    pass
 
 
 class DistributionBucket(TimedZoneRange):


### PR DESCRIPTION
This pr adjusts the expected return types following strava's spec but also looking at the actual return elements in postman. 

Also addresses part of #506 