### PR TITLE
Gear and Athlete type hierarchies (+ naive_datetime typing fixes)

### DIFF
--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -308,7 +308,7 @@ class Client:
             limit=limit,
         )
 
-    def get_athlete(self) -> model.Athlete:
+    def get_athlete(self) -> model.DetailedAthlete:
         """Gets the specified athlete; if athlete_id is None then retrieves a
         detail-level representation of currently authenticated athlete;
         otherwise summary-level representation returned of athlete.
@@ -322,13 +322,15 @@ class Client:
 
         Returns
         -------
-        class:`stravalib.model.Athlete`
+        class:`stravalib.model.DetailedAthlete`
             The athlete model object.
 
         """
         raw = self.protocol.get("/athlete")
 
-        return model.Athlete.model_validate({**raw, **{"bound_client": self}})
+        return model.DetailedAthlete.model_validate(
+            {**raw, **{"bound_client": self}}
+        )
 
     def update_athlete(
         self,
@@ -337,7 +339,7 @@ class Client:
         country: str | None = None,
         sex: str | None = None,
         weight: float | None = None,
-    ) -> model.Athlete:
+    ) -> model.DetailedAthlete:
         """Updates the properties of the authorized athlete.
 
         https://developers.strava.com/docs/reference/#api-Athletes-updateLoggedInAthlete
@@ -383,7 +385,7 @@ class Client:
             params["weight"] = float(weight)
 
         raw_athlete = self.protocol.put("/athlete", **params)
-        return model.Athlete.model_validate(
+        return model.DetailedAthlete.model_validate(
             {**raw_athlete, **{"bound_client": self}}
         )
 

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -1208,7 +1208,7 @@ class Client:
             result_fetcher=result_fetcher,
         )
 
-    def get_gear(self, gear_id: str) -> model.Gear:
+    def get_gear(self, gear_id: str) -> strava_model.DetailedGear:
         """Get details for an item of gear.
 
         https://developers.strava.com/docs/reference/#api-Gears
@@ -1220,11 +1220,10 @@ class Client:
 
         Returns
         -------
-        class:`stravalib.model.Gear`
-            The Bike or Shoe subclass object.
+        class:`stravalib.strava_model.DetailedGear`
 
         """
-        return model.Gear.model_validate(
+        return strava_model.DetailedGear.model_validate(
             self.protocol.get("/gear/{id}", id=gear_id)
         )
 

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -49,7 +49,6 @@ from stravalib.strava_model import (
     PolylineMap,
     Primary,
     SportType,
-    SummaryAthlete,
     SummaryGear,
     TimedZoneRange,
 )
@@ -347,7 +346,7 @@ class SummaryClub(MetaClub, strava_model.SummaryClub):
     club_type: Optional[str] = None
 
     @lazy_property
-    def members(self) -> BatchedResultsIterator[Athlete]:
+    def members(self) -> BatchedResultsIterator[strava_model.ClubAthlete]:
         """
         Lazy property to retrieve club members stored as Athlete objects.
 
@@ -407,8 +406,10 @@ class MetaAthlete(strava_model.MetaAthlete, BoundClientEntity):
     resource_state: Optional[int] = None
 
 
-# TODO: rename to detailed athlete
-class Athlete(strava_model.DetailedAthlete):
+class SummaryAthlete(MetaAthlete, strava_model.SummaryAthlete): ...
+
+
+class DetailedAthlete(SummaryAthlete, strava_model.DetailedAthlete):
     """Represents high level athlete information including
     their name, email, clubs they belong to, bikes, shoes, etc.
 
@@ -625,7 +626,7 @@ class Lap(
 ):
     # Field overrides from superclass for type extensions:
     activity: Optional[MetaActivity] = None
-    athlete: Optional[Athlete] = None
+    athlete: Optional[MetaAthlete] = None
 
     # Undocumented attributes:
     average_watts: Optional[float] = None

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -43,7 +43,6 @@ from stravalib.strava_model import (
     ActivityZone,
     BaseStream,
     Comment,
-    DetailedGear,
     ExplorerSegment,
     LatLng,
     PhotosSummary,
@@ -378,32 +377,6 @@ class DetailedClub(SummaryClub, strava_model.DetailedClub):
     pass
 
 
-class Gear(DetailedGear):
-    """
-    Represents a piece of gear (equipment) used in physical activities.
-    """
-
-    pass
-
-
-class Bike(Gear):
-    """
-    Represents a bike as a "type" / using the structure of
-    `stravalib.model.Gear`.
-    """
-
-    pass
-
-
-class Shoe(Gear):
-    """
-    Represents a Shoes as a "type" / using the structure of
-    `stravalib.model.Gear`.
-    """
-
-    pass
-
-
 class ActivityTotals(ActivityTotal):
     """An objecting containing a set of total values for an activity including
     elapsed time, moving time, distance and elevation gain."""
@@ -448,8 +421,6 @@ class Athlete(strava_model.DetailedAthlete):
 
     # Field overrides from superclass for type extensions:
     clubs: Optional[list[SummaryClub]] = None
-    bikes: Optional[list[SummaryGear]] = None
-    shoes: Optional[list[SummaryGear]] = None
 
     # Undocumented attributes:
     athlete_type: Optional[Literal["cyclist", "runner"]] = None
@@ -922,8 +893,7 @@ class DetailedActivity(
     """
 
     # field overrides from superclass for type extensions:
-    # TODO: should be SummaryGear - check returns
-    gear: Optional[Gear] = None
+    gear: Optional[SummaryGear] = None
     best_efforts: Optional[list[BestEffort]] = None  # type: ignore[assignment]
     # TODO: returning empty list should be  DetailedSegmentEffort object
     # TODO: test on activity with actual segments

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -97,11 +97,14 @@ def naive_datetime(value: Optional[AllDateTypes]) -> Optional[datetime]:
     YYYY-MM-DD[T]HH:MM[:SS[.ffffff]][Z or [±]HH[:]MM]
     """
 
-    if not value:
+    if value is None:
         return None
 
     if isinstance(value, (int, float)):
-        dt = datetime.fromtimestamp(value)
+        # If epoch is given, we have to assume it's UTC. When using the
+        # regular fromtimestamp(), epoch will be interpreted as in the
+        # _local_ timezone.
+        dt = datetime.utcfromtimestamp(value)
         return dt.replace(tzinfo=None)
     elif isinstance(value, str):
         try:
@@ -110,7 +113,7 @@ def naive_datetime(value: Optional[AllDateTypes]) -> Optional[datetime]:
         except ParserError:
             # Maybe timestamp was passed as string, e.g '1714305600'?
             try:
-                dt = datetime.fromtimestamp(float(value))
+                dt = datetime.utcfromtimestamp(float(value))
                 return dt.replace(tzinfo=None)
             except ValueError:
                 LOGGER.error(f"Invalid datetime value: {value}")

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -809,7 +809,6 @@ class SummarySegmentEffort(strava_model.SummarySegmentEffort):
 class BaseEffort(
     SummarySegmentEffort,
     strava_model.DetailedSegmentEffort,
-    BoundClientEntity,
 ):
     """
     Base class for a best effort or segment effort.

--- a/src/stravalib/tests/integration/test_client.py
+++ b/src/stravalib/tests/integration/test_client.py
@@ -9,7 +9,7 @@ from responses import matchers
 
 from stravalib.client import ActivityUploader
 from stravalib.exc import AccessUnauthorized, ActivityPhotoUploadFailed
-from stravalib.model import Athlete, SummaryAthlete, SummarySegment
+from stravalib.model import DetailedAthlete, SummaryAthlete, SummarySegment
 from stravalib.strava_model import SummaryActivity
 from stravalib.tests import RESOURCES_DIR
 from stravalib.unithelper import miles
@@ -52,7 +52,7 @@ def default_request_params():
 def test_get_athlete(mock_strava_api, client):
     mock_strava_api.get("/athlete", response_update={"id": 42})
     athlete = client.get_athlete()
-    assert isinstance(athlete, Athlete)
+    assert isinstance(athlete, DetailedAthlete)
     assert athlete.id == 42
     assert athlete.measurement_preference == "feet"
 

--- a/src/stravalib/tests/unit/test_model.py
+++ b/src/stravalib/tests/unit/test_model.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timezone
 
 import pytest
-from dateutil.parser import ParserError
 
 from stravalib import model
 from stravalib.model import (
@@ -322,7 +321,7 @@ class ModelTest(TestBase):
             datetime(2024, 4, 28, 12, 0),
             None,
         ),
-        ("Foo", None, ParserError),
+        ("Foo", None, ValueError),
     ],
 )
 def test_naive_datetime(input_value, expected_output, exception):

--- a/src/stravalib/tests/unit/test_model.py
+++ b/src/stravalib/tests/unit/test_model.py
@@ -300,14 +300,21 @@ class ModelTest(TestBase):
 @pytest.mark.parametrize(
     "input_value, expected_output, exception",
     [
+        (0, datetime(1970, 1, 1), None),
         ("2024-04-28T12:00:00Z", datetime(2024, 4, 28, 12, 0), None),
         (
-            int(datetime(2022, 4, 28, 12, 0).timestamp()),
+            int(datetime(2022, 4, 28, 12, 0, tzinfo=timezone.utc).timestamp()),
             datetime(2022, 4, 28, 12, 0),
             None,
         ),
         (
-            str(int(datetime(2022, 4, 28, 12, 0).timestamp())),
+            str(
+                int(
+                    datetime(
+                        2022, 4, 28, 12, 0, tzinfo=timezone.utc
+                    ).timestamp()
+                )
+            ),
             datetime(2022, 4, 28, 12, 0),
             None,
         ),
@@ -322,6 +329,8 @@ class ModelTest(TestBase):
             None,
         ),
         ("Foo", None, ValueError),
+        ({"foo": 42}, None, ValueError),
+        (None, None, None),
     ],
 )
 def test_naive_datetime(input_value, expected_output, exception):

--- a/src/stravalib/tests/unit/test_model.py
+++ b/src/stravalib/tests/unit/test_model.py
@@ -264,7 +264,7 @@ class ModelTest(TestBase):
                 },
             ]
         }
-        a = model.Athlete.model_validate(d)
+        a = model.DetailedAthlete.model_validate(d)
 
         self.assertEqual(3, len(a.clubs))
         self.assertEqual("Team Roaring Mouse", a.clubs[0].name)


### PR DESCRIPTION
This corrects the type hierarchies for `Gear` and `Athlete` types, + several other typing issues I encountered in the `pydantic-v2` branch. The remaining (3) typing issues will be resolved by #510 .