### PR TITLE
Add: what's new section to the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,6 +115,7 @@ html_theme_options = {
     # "navbar_align": "left",  # [left, content, right] For testing that the navbar items align properly
     "github_url": "https://github.com/stravalib/stravalib",
     "footer_start": ["copyright"],
+    "announcement": "<a href='stravalib-2.html'>Stravalib 2.x is out 🚀! Check out our migration guide for tips on changes from Stravalib V1!</a>",
 }
 
 html_context = {

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,3 +115,9 @@ Code/API Reference <reference>
 
 Contribute <contributing/intro.md>
 :::
+
+:::{toctree}
+:hidden:
+:caption: What's New
+Get Started <whats-new/changelog>
+:::

--- a/docs/reference/client.rst
+++ b/docs/reference/client.rst
@@ -60,17 +60,14 @@ Activity related methods
    :toctree: api/
 
    Client.get_activity
-   Client.get_friend_activities
    Client.create_activity
    Client.update_activity
    Client.upload_activity
-   Client.delete_activity
    Client.get_activity_zones
    Client.get_activity_comments
    Client.get_activity_kudos
    Client.get_activity_photos
    Client.get_activity_laps
-   Client.get_related_activities
    Client._validate_activity_type
 
 Segment related methods

--- a/docs/reference/model.rst
+++ b/docs/reference/model.rst
@@ -1,53 +1,124 @@
-.. automodule:: stravalib.model
-    :inherited-members: BaseModel
+============
+Model
+============
 
-.. If you use both automodule and autosummary you duplicate autodocs efforts
-.. Summary Functions
-.. -------------------------------
-.. .. autosummary::
-..    :toctree: api/
+.. currentmodule:: stravalib.model
 
-..    lazy_property
-..    check_valid_location
-..    naive_datetime
 
-.. Summary Classes
-.. -------------------------------
-.. .. autosummary::
-..    :toctree: api/
+.. We were using automodule here but autosummary was also used
+.. automodule supersedes autosummary. but also had an inheritance
+.. setting (BaseModel) see below. Testing a custom page that is
+.. cleaner to read.
+.. .. automodule:: stravalib.model
+..     :inherited-members: BaseModel
 
-..    DeprecatedSerializableMixin
-..    BackwardCompatibilityMixin
-..    BoundClientEntity
-..    LatLon
-..    Club
-..    Gear
-..    Bike
-..    Shoe
-..    ActivityTotals
-..    AthleteStats
-..    Athlete
-..    ActivityComment
-..    ActivityPhotoPrimary
-..    ActivityPhotoMeta
-..    ActivityPhoto
-..    ActivityKudos
-..    ActivityLap
-..    Map
-..    Split
-..    SegmentExplorerResult
-..    AthleteSegmentStats
-..    AthletePrEffort
-..    Segment
-..    SegmentEffortAchievement
-..    BaseEffort
-..    BestEffort
-..    SegmentEffort
-..    Activity
-..    DistributionBucket
-..    BaseActivityZone
-..    Stream
-..    Route
-..    Subscription
-..    SubscriptionCallback
-..    SubscriptionUpdate
+
+
+Summary Functions
+------------------
+.. autosummary::
+   :toctree: api/
+
+   check_valid_location
+   lazy_property
+   naive_datetime
+
+
+Helper Classes
+----------------
+
+.. autosummary::
+   :toctree: api/
+
+   BoundClientEntity
+
+Unit & Conversion Classes
+--------------------------
+
+.. autosummary::
+   :toctree: api/
+
+   Distance
+   Duration
+   Timezone
+   Velocity
+
+Summary Activity Classes
+-------------------------
+
+.. autosummary::
+   :toctree: api/
+
+   MetaActivity
+   SummaryActivity
+   DetailedActivity
+   ClubActivity
+   TimedZoneDistribution
+   ActivityZone
+   ActivityTotals
+   ActivityComment
+   Lap
+   Split
+   RelaxedActivityType
+   RelaxedSportType
+   ActivityPhotoPrimary
+   ActivityPhotoMeta
+   ActivityPhoto
+
+Summary Athlete Classes
+-------------------------
+
+.. autosummary::
+   :toctree: api/
+
+   AthleteStats
+   MetaAthlete
+   SummaryAthlete
+   DetailedAthlete
+   AthletePrEffort
+   AthleteSegmentStats
+
+Route / Segment Classes
+-------------------------
+
+.. autosummary::
+   :toctree: api/
+
+   LatLon
+   SummarySegment
+   Segment
+   SegmentEffort
+   SegmentEffortAchievement
+   SummarySegmentEffort
+   Map
+   SegmentExplorerResult
+   BaseEffort
+   BestEffort
+   Route
+   Stream
+
+
+
+Subscription Classes
+-------------------------
+.. autosummary::
+   :toctree: api/
+
+   Subscription
+   SubscriptionCallback
+   SubscriptionUpdate
+
+Club / Effort / Performance Classes
+------------------------------------
+   Split
+   Club
+   BaseEffort
+   BestEffort
+   DistributionBucket
+   BaseActivityZone
+
+Club Classes
+-------------
+   MetaClub
+   SummaryClub
+   DetailedClub

--- a/docs/whats-new/changelog.md
+++ b/docs/whats-new/changelog.md
@@ -1,0 +1,7 @@
+# Changelog: What's new with stravalib
+
+
+:::{include} ./changelog.md
+:start-line: 1
+
+:::

--- a/docs/whats-new/stravalib-2.md
+++ b/docs/whats-new/stravalib-2.md
@@ -1,0 +1,3 @@
+# Stravalib V2 Migration Guide
+
+More here...

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -1184,12 +1184,11 @@ class ClubActivity(strava_model.ClubActivity):
 
     Notes
     -----
-    The actual strava API specification suggests that this should
-    return a MetaAthlete Object for the activities' athlete information.
-    However, while that object should return the correct values, it is missing what is
-     actually returned, i.e., resource_state, first name and
-    last initial. So this object doesn't match the spec but does match the
-    actual return.
+    The Strava API suggests returning a `MetaAthlete` object for activities' athlete
+    info. However, the actual return lacks expected attributes like resource_state,
+    first name, and last initial, differing from the spec but matching the actual
+    data.
+
     """
 
     # Intentional class override as spec returns metaAthlete object


### PR DESCRIPTION
This PR just cleans up our docs and adds a banner + a what's new section.

Right now the docs won't build because of a recursion issue mentioned in #538 which we need to fix first. i'm going to take a quick look at that next to see how involved it will be to address it. because of how we're building our docs, i'm not sure how to create the :noindex: flag to ignore the recursion issue (which is a duplicated attribute in two classes. (this happens a few times). 

UPDATE:

i actually looked into this and am not sure how to handle things here. We could merge just to work on the discussion around what's changed. but it seems like there may be some inheritance issues that we need to sort out first