### PR TITLE
Fix: Photos endpoint cleanup

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 - Fix: Add custom types that pass static type checks (@jsamoocha, #534)
 - Fix: Replace invariant with covariant container types (@lwasser, @jsamoocha, #510)
 - Fix: Rename unithelper.py --> unit_helper.py (@lwasser, #535)
+- Fix: Update & check photos endpoint (@lwasser)
 
 ## v1.7
 

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -654,13 +654,6 @@ class Client:
         class: `model.DetailedActivity`
             An Activity object containing the requested activity data.
 
-        Examples
-        --------
-        # Assuming an authenticated client
-        >> activity = client.get_activity(activity_id = 12345677)
-        >> activity.moving_time
-        1234
-
         """
         raw = self.protocol.get(
             "/activities/{id}",
@@ -1161,11 +1154,6 @@ class Client:
         -------
         class:`BatchedResultsIterator`
             An iterator of :class:`stravalib.model.ActivityPhoto` objects.
-
-        Examples
-        --------
-        # Assuming an authenticated client
-        >> activity = client.get_activity_photos(activity_id = 12345677)
 
         """
         params: dict[str, Any] = {}

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -654,6 +654,13 @@ class Client:
         class: `model.DetailedActivity`
             An Activity object containing the requested activity data.
 
+        Examples
+        --------
+        # Assuming an authenticated client
+        >> activity = client.get_activity(activity_id = 12345677)
+        >> activity.moving_time
+        1234
+
         """
         raw = self.protocol.get(
             "/activities/{id}",
@@ -1154,6 +1161,11 @@ class Client:
         -------
         class:`BatchedResultsIterator`
             An iterator of :class:`stravalib.model.ActivityPhoto` objects.
+
+        Examples
+        --------
+        # Assuming an authenticated client
+        >> activity = client.get_activity_photos(activity_id = 12345677)
 
         """
         params: dict[str, Any] = {}

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -38,7 +38,6 @@ from dateutil import parser
 from dateutil.parser import ParserError
 from pydantic import (
     AliasChoices,
-    AnyHttpUrl,
     BaseModel,
     Field,
     GetCoreSchemaHandler,
@@ -759,7 +758,7 @@ class PhotosSummary(strava_model.PhotosSummary):
     https://developers.strava.com/docs/reference/#api-models-PhotosSummary
     """
 
-    primary: Optional[PhotosSummary_primary] = None
+    primary: Optional[PhotosSummaryPrimary] = None
 
     # Undocumented by strava
     use_primary_photo: Optional[bool] = None
@@ -788,7 +787,7 @@ class ActivityPhoto(BaseModel):
     type: Optional[int] = None
     unique_id: Optional[str] = None
     uploaded_at: Optional[datetime] = None
-    urls: Optional[dict[str, AnyHttpUrl]] = None
+    urls: Optional[dict[str, str]] = None
 
     # TODO: i don't see these in the actual returns but they are used below
     ref: Optional[str] = None

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -729,20 +729,6 @@ class PhotosSummary_primary(strava_model.Primary):
     returned. This model represents what is actually returned
     """
 
-    # TODO: we should use strava_model.Primary instead
-    # However there is a mapping issue
-    # id should be unique_id - i'm guessing media type is video vs image
-    # i'm not sure if user will want that -
-    # what is the best path forward here?
-    """
-    "unique_id": "8d9e546c-5da1-46cb-973e-c55bb3be88bd",
-            "urls": {
-                "600": "https://dgtzuqphqg23d.cloudfront.net/PNON86jIyK-xCnvSXhfESDYO--7cwvweK2fQ86NwOws-768x354.jpg",
-                "100": "https://dgtzuqphqg23d.cloudfront.net/PNON86jIyK-xCnvSXhfESDYO--7cwvweK2fQ86NwOws-128x59.jpg"
-            },
-            "source": 1,
-            "media_type": 1
-    """
     # Strava_model has this defined as id but unique_id is the correct attr name
     # it's also defined as a int but should be a string
     unique_id: str | None

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -719,18 +719,18 @@ class ActivityComment(Comment):
 # strava_model Primary is fine for this but we may
 # have to add some mapping
 class PhotosSummary_primary(strava_model.Primary):
-    """A object to store data about the primary photo of a Strava activity
+    """An object to store data about the primary photo of a Strava activity
 
     Notes
     -----
     https://developers.strava.com/docs/reference/#api-models-PhotosSummary_primary
-    This object is nor returned in strava_model but it is documented in the
+    This object is not returned in strava_model, but it is documented in the
     Strava API V3 spec. The Spec documentation deviates from what is actually
-    returned. This model represents what is actually returned
+    returned. This model represents what is actually returned.
     """
 
     # Strava_model has this defined as id but unique_id is the correct attr name
-    # it's also defined as a int but should be a string
+    # it's also defined as an int but should be a string
     unique_id: str | None
     media_type: int | None = None
 

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -717,7 +717,7 @@ class ActivityComment(Comment):
 
 # strava_model Primary is fine for this but we may
 # have to add some mapping
-class PhotosSummary_primary(strava_model.Primary):
+class PhotosSummaryPrimary(strava_model.Primary):
     """An object to store data about the primary photo of a Strava activity
 
     Notes


### PR DESCRIPTION
I know that this wasn't in our list of issues but the photos endpoint diverged from the Spec so I just cleaned it up a bit.  
The changes here just realign things with the strava spec where possible. i do understand that get_activity_photos is not a supported endpoint by strava currently. but i was able to get it to work after a lot of digging and then a realization that I should have just read the docstring for that method 🙃 first (instead of last) 🙈 i'm sorry for the excessive pings yesterday @jsamoocha 