### PR TITLE
Activity Comment cleanup

### DIFF
--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -1063,7 +1063,7 @@ class Client:
         activity_id: int,
         markdown: bool = False,
         limit: int | None = None,
-    ) -> BatchedResultsIterator[model.ActivityComment]:
+    ) -> BatchedResultsIterator[strava_model.Comment]:
         """Gets the comments for an activity.
 
         https://developers.strava.com/docs/reference/#api-Activities-getCommentsByActivityId
@@ -1080,7 +1080,7 @@ class Client:
         Returns
         -------
         class:`BatchedResultsIterator`
-            An iterator of :class:`stravalib.model.ActivityComment` objects.
+            An iterator of :class:`stravalib.strava_model.Comment` objects.
 
         """
         result_fetcher = functools.partial(
@@ -1091,7 +1091,7 @@ class Client:
         )
 
         return BatchedResultsIterator(
-            entity=model.ActivityComment,
+            entity=strava_model.Comment,
             bind_client=self,
             result_fetcher=result_fetcher,
             limit=limit,

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -702,7 +702,7 @@ class DetailedAthlete(SummaryAthlete, strava_model.DetailedAthlete):
         return self.bound_client.get_athlete_stats(self.id)
 
 
-class ActivityPhotoPrimary(Primary):
+class ActivityPhotoPrimary(strava_model.Primary):
     """
     Represents the primary photo for an activity.
 
@@ -749,7 +749,7 @@ class PhotosSummary(strava_model.PhotosSummary):
     https://developers.strava.com/docs/reference/#api-models-PhotosSummary
     """
 
-    primary: Optional[PhotosSummaryPrimary] = None
+    primary: Optional[ActivityPhotoPrimary] = None
 
     # Undocumented by strava
     use_primary_photo: Optional[bool] = None

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -702,23 +702,14 @@ class DetailedAthlete(SummaryAthlete, strava_model.DetailedAthlete):
         return self.bound_client.get_athlete_stats(self.id)
 
 
-class ActivityComment(Comment):
+class ActivityPhotoPrimary(Primary):
     """
-    A class representing a comment on an activity.
+    Represents the primary photo for an activity.
 
     Attributes
     ----------
-    athlete : Athlete, optional
-        The athlete associated with the comment.
-    """
-
-    athlete: Optional[SummaryAthlete] = None
-
-
-# strava_model Primary is fine for this but we may
-# have to add some mapping
-class PhotosSummaryPrimary(strava_model.Primary):
-    """An object to store data about the primary photo of a Strava activity
+    use_primary_photo : bool, optional
+        Indicates whether the photo is used as the primary photo.
 
     Notes
     -----
@@ -1071,7 +1062,7 @@ class AthleteSegmentStats(
 
 class MetaActivity(strava_model.MetaActivity, BoundClientEntity):
     @lazy_property
-    def comments(self) -> BatchedResultsIterator[ActivityComment]:
+    def comments(self) -> BatchedResultsIterator[Comment]:
         """Retrieves comments for a specific activity id."""
         assert self.bound_client is not None
         return self.bound_client.get_activity_comments(self.id)


### PR DESCRIPTION
I could be missing something here. But part of the docs issues related to duplicated attributes. 

When i looked at model.ActivityComment is had a single attribute athlete and it inherited from BaseModel. however in strava_model there is a Comment object that has the same attr +. The spec calls for a return of a Comment object so I just removed the model.ActivityComment and imported strava_model.Comment instead. 

If there was some reason that we added this, lt's keep it. But it seems to be at this point it's a redundant class. I wondered if maybe the strava_model didn't have `Comment` before and now it does.