### PR TITLE
fix(codecov): relax code coverage requirements

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+# Set non-blocking status checks
+coverage:
+  status:
+    project:
+      default:
+        # Allows 10% drop from previous base commit
+        threshold: 10%
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
This is a tiny pr to relax the requirements for code cov. this way it won't fail a pr if the test coverage is within 10% of main's current state. 