### PR TITLE
Specialize type for on summary activity

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 - Add: `get_athelete_zones` method on client (@enadeau, #508)
 
+### Fixed
+
+- Some override moved from DetailedActivity to SummaryActivity (@enadeau, #570)
+
 ## v2.0.0
 
 ### Major Changes in This Release

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -1242,12 +1242,19 @@ class SummaryActivity(MetaActivity, strava_model.SummaryActivity):
 
     # field overrides from superclass for type extensions:
     athlete: MetaAthlete | None = None
+    average_speed: VelocityType | None = None
+    distance: DistanceType | None = None
+    elapsed_time: DurationType | None = None
     # These force validator to run on lat/lon
     start_latlng: LatLon | None = None
     end_latlng: LatLon | None = None
     map: Map | None = None
+    max_speed: VelocityType | None = None
+    moving_time: DurationType | None = None
     type: RelaxedActivityType | None = None
     sport_type: RelaxedSportType | None = None
+    timezone: TimezoneType | None = None
+    total_elevation_gain: DistanceType | None = None
 
     _latlng_check = field_validator(
         "start_latlng", "end_latlng", mode="before"
@@ -1263,8 +1270,6 @@ class DetailedActivity(
     """
 
     # Field overrides from superclass for type extensions:
-    distance: DistanceType | None = None
-    total_elevation_gain: DistanceType | None = None
     gear: SummaryGear | None = None
     best_efforts: Sequence[BestEffort] | None = None
     # TODO: returning empty Sequence should be  DetailedSegmentEffort object
@@ -1275,11 +1280,6 @@ class DetailedActivity(
     splits_standard: Sequence[Split] | None = None
     photos: PhotosSummary | None = None
     laps: Sequence[Lap] | None = None
-    elapsed_time: DurationType | None = None
-    moving_time: DurationType | None = None
-    average_speed: VelocityType | None = None
-    max_speed: VelocityType | None = None
-    timezone: TimezoneType | None = None
 
     # Added for backward compatibility
     # TODO maybe deprecate?


### PR DESCRIPTION

closes #570 

## Description

Some field of ActivitySummary were only casted into our custom type on DetailActivity. This PR addresses that. 
Hopefully I've found them all.

I feel like this change is not breaking but not 100% sure. I'd take the opinion of the other dev on that

## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [ ] This is a infrastructure update (docs, ci, etc)
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [x] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.