### PR TITLE
docs(fix): missing comma in all contribs json

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,6 +1,6 @@
 {
   "projectName": "stravalib",
-  "projectOwner": "stravalib"
+  "projectOwner": "stravalib",
   "files": [
     "README.md"
   ],


### PR DESCRIPTION
I missed a comma in the json config file 🙈 