### PR TITLE
FIX: ensures ActivityType instances can be compared to str

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Some override moved from DetailedActivity to SummaryActivity (@enadeau, #570)
+- Ensures ActivityType instances can be compared to str (@jsamoocha, #583)
 
 ## v2.0.0
 

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -522,6 +522,13 @@ class RelaxedActivityType(ActivityType):
             values = "Workout"
         return values
 
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, RelaxedActivityType):
+            return other == self
+        elif isinstance(other, str):
+            return other == self.root
+        return False
+
 
 class RelaxedSportType(SportType):
     """A class that extends the list of Literal values allowed for Sport Types
@@ -551,6 +558,13 @@ class RelaxedSportType(SportType):
             )
             values = "Workout"
         return values
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, RelaxedSportType):
+            return other == self
+        elif isinstance(other, str):
+            return other == self.root
+        return False
 
 
 class LatLon(LatLng):

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -524,7 +524,7 @@ class RelaxedActivityType(ActivityType):
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, RelaxedActivityType):
-            return other == self
+            return other.root == self.root
         elif isinstance(other, str):
             return other == self.root
         return False
@@ -561,7 +561,7 @@ class RelaxedSportType(SportType):
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, RelaxedSportType):
-            return other == self
+            return other.root == self.root
         elif isinstance(other, str):
             return other == self.root
         return False

--- a/src/stravalib/tests/unit/test_model.py
+++ b/src/stravalib/tests/unit/test_model.py
@@ -17,8 +17,6 @@ from stravalib.model import (
     Duration,
     Lap,
     LatLon,
-    RelaxedActivityType,
-    RelaxedSportType,
     Route,
     Segment,
     SegmentEffort,
@@ -145,7 +143,6 @@ def test_subscription_callback_field_names():
     assert sub_callback.hub_verify_token == "STRAVA"
 
 
-# TODO: do we want to continue to support type?
 @pytest.mark.parametrize(
     "klass,attr,given_type,expected_type",
     (
@@ -160,11 +157,8 @@ def test_subscription_callback_field_names():
 def test_relaxed_activity_type_validation(
     klass, attr, given_type, expected_type
 ):
-    obj = getattr(klass(**{attr: given_type}), attr)
-    if attr == "sport_type":
-        assert obj == RelaxedSportType(root=expected_type)
-    else:
-        assert obj == RelaxedActivityType(root=expected_type)
+    obj = klass.model_validate({attr: given_type})
+    assert getattr(obj, attr) == expected_type
 
 
 @pytest.mark.parametrize(

--- a/src/stravalib/tests/unit/test_model.py
+++ b/src/stravalib/tests/unit/test_model.py
@@ -162,40 +162,23 @@ def test_relaxed_activity_type_validation(
     assert getattr(obj, attr) == expected_type
 
 
-def test_relaxed_activity_type_equality():
-    a = SummaryActivity.model_validate({"type": "Run"})
-    b = SummaryActivity.model_validate({"type": "Run"})
-    assert a.type == b.type
-
-
-def test_relaxed_activity_type_non_equality():
-    a = SummaryActivity.model_validate({"type": "Run"})
-    b = SummaryActivity.model_validate({"type": "Ride"})
-    assert a.type != b.type
-
-
-def test_relaxed_activity_type_different_fields():
-    a = SummaryActivity.model_validate({"type": "Run"})
-    b = SummaryActivity.model_validate({"id": 42})
-    assert a.type != b.id
-
-
-def test_relaxed_sport_type_equality():
-    a = SummaryActivity.model_validate({"sport_type": "Run"})
-    b = SummaryActivity.model_validate({"sport_type": "Run"})
-    assert a.sport_type == b.sport_type
-
-
-def test_relaxed_sport_type_non_equality():
-    a = SummaryActivity.model_validate({"sport_type": "Run"})
-    b = SummaryActivity.model_validate({"sport_type": "Ride"})
-    assert a.sport_type != b.sport_type
-
-
-def test_relaxed_sport_type_different_fields():
-    a = SummaryActivity.model_validate({"sport_type": "Run"})
-    b = SummaryActivity.model_validate({"id": 42})
-    assert a.sport_type != b.id
+@pytest.mark.parametrize(
+    "a_attr,a_value,b_attr,b_value,expected_attr_equality",
+    (
+        ("type", "Run", "type", "Run", True),
+        ("type", "Run", "type", "Ride", False),
+        ("type", "Run", "id", 42, False),
+        ("sport_type", "Run", "sport_type", "Run", True),
+        ("sport_type", "Run", "sport_type", "Ride", False),
+        ("sport_type", "Run", "id", 42, False),
+    ),
+)
+def test_relaxed_activity_type_equality(
+    a_attr, a_value, b_attr, b_value, expected_attr_equality
+):
+    a = SummaryActivity.model_validate({a_attr: a_value})
+    b = SummaryActivity.model_validate({b_attr: b_value})
+    assert (getattr(a, a_attr) == getattr(b, b_attr)) == expected_attr_equality
 
 
 @pytest.mark.parametrize(

--- a/src/stravalib/tests/unit/test_model.py
+++ b/src/stravalib/tests/unit/test_model.py
@@ -23,6 +23,7 @@ from stravalib.model import (
     SegmentExplorerResult,
     Split,
     SubscriptionCallback,
+    SummaryActivity,
     SummarySegmentEffort,
     Timezone,
     Velocity,
@@ -159,6 +160,42 @@ def test_relaxed_activity_type_validation(
 ):
     obj = klass.model_validate({attr: given_type})
     assert getattr(obj, attr) == expected_type
+
+
+def test_relaxed_activity_type_equality():
+    a = SummaryActivity.model_validate({"type": "Run"})
+    b = SummaryActivity.model_validate({"type": "Run"})
+    assert a.type == b.type
+
+
+def test_relaxed_activity_type_non_equality():
+    a = SummaryActivity.model_validate({"type": "Run"})
+    b = SummaryActivity.model_validate({"type": "Ride"})
+    assert a.type != b.type
+
+
+def test_relaxed_activity_type_different_fields():
+    a = SummaryActivity.model_validate({"type": "Run"})
+    b = SummaryActivity.model_validate({"id": 42})
+    assert a.type != b.id
+
+
+def test_relaxed_sport_type_equality():
+    a = SummaryActivity.model_validate({"sport_type": "Run"})
+    b = SummaryActivity.model_validate({"sport_type": "Run"})
+    assert a.sport_type == b.sport_type
+
+
+def test_relaxed_sport_type_non_equality():
+    a = SummaryActivity.model_validate({"sport_type": "Run"})
+    b = SummaryActivity.model_validate({"sport_type": "Ride"})
+    assert a.sport_type != b.sport_type
+
+
+def test_relaxed_sport_type_different_fields():
+    a = SummaryActivity.model_validate({"sport_type": "Run"})
+    b = SummaryActivity.model_validate({"id": 42})
+    assert a.sport_type != b.id
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes #583

## Description

Ensures ActivityType instances can be compared to str. This prevents an undocumented breaking change from stravalib v1.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Does your PR include tests

- [x] Yes

Updated existing test.

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.
