### PR TITLE
feat: Return optional SummaryAthlete via exchange code for token with user request

### DIFF
--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Add: `SummaryAthlete` return to exchange_code_for_token (@lwasser, #552)
-- Add: Add more information about how our mock text fixture works (@lwasser, #292)
+- Add: Add more information about how our mock test fixture works (@lwasser, #292)
 
 ### Fixed
 - Fix: Update `segment_efforts` api and return warnings (@lwasser, #321)

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
-- Fix: Update segment_efforts api and return warnings (@lwasser, #321)
+### Fixed
+- Fix: Update `segment_efforts` api and return warnings (@lwasser, #321)
+
+### Added
+
+- Add: `SummaryAthlete` return to exchange_code_for_token (@lwasser, #552)
 
 ## v2.1.0
 

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -224,6 +224,7 @@ class Client:
             code=code,
             return_athlete=return_athlete,
         )
+        # This won't work because a dict has a length
         if len(raw) == 2:
             access_info, athlete_data = cast(
                 Tuple[AccessInfo, dict[str, Any]], raw

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -175,7 +175,11 @@ class Client:
         )
 
     def exchange_code_for_token(
-        self, client_id: int, client_secret: str, code: str
+        self,
+        client_id: int,
+        client_secret: str,
+        code: str,
+        return_athlete=False,
     ) -> AccessInfo:
         """Exchange the temporary authorization code (returned with redirect
         from Strava authorization URL) for a short-lived access token and a
@@ -189,6 +193,10 @@ class Client:
             The developer client secret
         code : str
             The temporary authorization code
+        return_athlete : bool (default = False)
+            Whether to return a SummaryAthlete object (or not)
+            This parameter is currently undocumented and could change
+            at any time.
 
         Returns
         -------
@@ -196,9 +204,22 @@ class Client:
             Dictionary containing the access_token, refresh_token and
             expires_at (number of seconds since Epoch when the provided access
             token will expire)
+        tuple
+            Contains:
+             - the access token dict
+             - a `SummaryAthlete` object representing the authenticated user.
+
+        Notes
+        -----
+        Strava by default returns SummaryAthlete information during
+        this exchange. However this return is currently undocumented
+        and could change at any time.
         """
         return self.protocol.exchange_code_for_token(
-            client_id=client_id, client_secret=client_secret, code=code
+            client_id=client_id,
+            client_secret=client_secret,
+            code=code,
+            return_athlete=return_athlete,
         )
 
     def refresh_access_token(

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -232,12 +232,9 @@ class Client:
                 return_athlete=return_athlete,
             )
 
-        # # This won't work because a dict has a length
-        # if len(raw) == 2:
-        #     access_info, athlete_data = cast(
-        #         Tuple[AccessInfo, dict[str, Any]], raw
-        #     )
-        if return_athlete:
+        # Only return both if both exist, this will fail quietly if Strava
+        # modifies the end point return
+        if return_athlete and athlete_data:
             summary_athlete = SummaryAthlete.model_validate(athlete_data)
             return access_info, summary_athlete
 

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -179,8 +179,8 @@ class Client:
         client_id: int,
         client_secret: str,
         code: str,
-        return_athlete=False,
-    ) -> AccessInfo:
+        return_athlete: bool = False,
+    ) -> AccessInfo | tuple[AccessInfo, model.SummaryAthlete]:
         """Exchange the temporary authorization code (returned with redirect
         from Strava authorization URL) for a short-lived access token and a
         refresh token (used to obtain the next access token later on).

--- a/src/stravalib/protocol.py
+++ b/src/stravalib/protocol.py
@@ -167,7 +167,7 @@ class ApiV3(metaclass=abc.ABCMeta):
         client_secret: str,
         code: str,
         return_athlete: bool | None = False,
-    ) -> AccessInfo | tuple[AccessInfo, dict]:
+    ) -> AccessInfo | tuple[AccessInfo, dict[str, Any]]:
         """Exchange the temporary authorization code (returned with redirect
         from Strava authorization URL) for a short-lived access token and a
         refresh token (used to obtain the next access token later on).
@@ -210,7 +210,7 @@ class ApiV3(metaclass=abc.ABCMeta):
         }
         self.access_token = response["access_token"]
         if return_athlete:
-            # This will potentially None if the undocumented athlete response is removed from the endpoint by Strava 
+            # This will potentially None if the undocumented athlete response is removed from the endpoint by Strava
             return access_info, response.get("athlete")
         else:
             return access_info

--- a/src/stravalib/protocol.py
+++ b/src/stravalib/protocol.py
@@ -166,7 +166,7 @@ class ApiV3(metaclass=abc.ABCMeta):
         client_id: int,
         client_secret: str,
         code: str,
-        return_athlete: bool | None = False,
+        return_athlete: bool = False,
     ) -> AccessInfo | tuple[AccessInfo, dict[str, Any] | None]:
         """Exchange the temporary authorization code (returned with redirect
         from Strava authorization URL) for a short-lived access token and a
@@ -212,7 +212,7 @@ class ApiV3(metaclass=abc.ABCMeta):
         if return_athlete:
             # This will None if Strava removes undocumented athlete response
             # from the undocumented endpoint return
-            return access_info, response.get("athlete")
+            return (access_info, response.get("athlete"))
         else:
             return access_info
 

--- a/src/stravalib/protocol.py
+++ b/src/stravalib/protocol.py
@@ -15,6 +15,7 @@ from urllib.parse import urlencode, urljoin, urlunsplit
 import requests
 
 from stravalib import exc
+from stravalib.model import SummaryAthlete
 
 if TYPE_CHECKING:
     from _typeshed import SupportsRead
@@ -162,7 +163,11 @@ class ApiV3(metaclass=abc.ABCMeta):
         )
 
     def exchange_code_for_token(
-        self, client_id: int, client_secret: str, code: str
+        self,
+        client_id: int,
+        client_secret: str,
+        code: str,
+        return_athlete: bool | None = False,
     ) -> AccessInfo:
         """Exchange the temporary authorization code (returned with redirect
         from Strava authorization URL) for a short-lived access token and a
@@ -176,6 +181,10 @@ class ApiV3(metaclass=abc.ABCMeta):
             The developer client secret
         code : str
             The temporary authorization code
+        return_athlete : bool (optional, default=False)
+            Whether to return the `SummaryAthlete` object with the token
+            response. This behavior is currently undocumented and could
+            change at any time. Default is `False`.
 
         Returns
         -------
@@ -200,7 +209,12 @@ class ApiV3(metaclass=abc.ABCMeta):
             "expires_at": response["expires_at"],
         }
         self.access_token = response["access_token"]
-        return access_info
+
+        if return_athlete:
+            athlete_info = SummaryAthlete.model_validate(response["athlete"])
+            return access_info, athlete_info
+        else:
+            return access_info
 
     def refresh_access_token(
         self, client_id: int, client_secret: str, refresh_token: str

--- a/src/stravalib/protocol.py
+++ b/src/stravalib/protocol.py
@@ -210,8 +210,7 @@ class ApiV3(metaclass=abc.ABCMeta):
         }
         self.access_token = response["access_token"]
         if return_athlete:
-            # This will return None if the athlete key is missing so it doesn't
-            # fail if the undocumented part of the response is removed
+            # This will potentially None if the undocumented athlete response is removed from the endpoint by Strava 
             return access_info, response.get("athlete")
         else:
             return access_info

--- a/src/stravalib/protocol.py
+++ b/src/stravalib/protocol.py
@@ -167,7 +167,7 @@ class ApiV3(metaclass=abc.ABCMeta):
         client_secret: str,
         code: str,
         return_athlete: bool | None = False,
-    ) -> AccessInfo | tuple[AccessInfo, dict[str, Any]]:
+    ) -> AccessInfo | tuple[AccessInfo, dict[str, Any] | None]:
         """Exchange the temporary authorization code (returned with redirect
         from Strava authorization URL) for a short-lived access token and a
         refresh token (used to obtain the next access token later on).

--- a/src/stravalib/protocol.py
+++ b/src/stravalib/protocol.py
@@ -210,7 +210,7 @@ class ApiV3(metaclass=abc.ABCMeta):
         }
         self.access_token = response["access_token"]
         if return_athlete:
-            # This will None if Strava removes undocumented athlete response
+            # This will be None if Strava removes undocumented athlete response
             # from the undocumented endpoint return
             return access_info, response.get("athlete")
         else:

--- a/src/stravalib/protocol.py
+++ b/src/stravalib/protocol.py
@@ -168,7 +168,7 @@ class ApiV3(metaclass=abc.ABCMeta):
         client_secret: str,
         code: str,
         return_athlete: bool | None = False,
-    ) -> AccessInfo:
+    ) -> AccessInfo | tuple[AccessInfo, SummaryAthlete]:
         """Exchange the temporary authorization code (returned with redirect
         from Strava authorization URL) for a short-lived access token and a
         refresh token (used to obtain the next access token later on).

--- a/src/stravalib/protocol.py
+++ b/src/stravalib/protocol.py
@@ -167,7 +167,7 @@ class ApiV3(metaclass=abc.ABCMeta):
         client_secret: str,
         code: str,
         return_athlete: bool = False,
-    ) -> AccessInfo | tuple[AccessInfo, dict[str, Any] | None]:
+    ) -> tuple[AccessInfo, dict[str, Any] | None]:
         """Exchange the temporary authorization code (returned with redirect
         from Strava authorization URL) for a short-lived access token and a
         refresh token (used to obtain the next access token later on).
@@ -212,9 +212,9 @@ class ApiV3(metaclass=abc.ABCMeta):
         if return_athlete:
             # This will None if Strava removes undocumented athlete response
             # from the undocumented endpoint return
-            return (access_info, response.get("athlete"))
+            return access_info, response.get("athlete")
         else:
-            return access_info
+            return access_info, None
 
     def refresh_access_token(
         self, client_id: int, client_secret: str, refresh_token: str

--- a/src/stravalib/protocol.py
+++ b/src/stravalib/protocol.py
@@ -210,7 +210,8 @@ class ApiV3(metaclass=abc.ABCMeta):
         }
         self.access_token = response["access_token"]
         if return_athlete:
-            # This will potentially None if the undocumented athlete response is removed from the endpoint by Strava
+            # This will None if Strava removes undocumented athlete response
+            # from the undocumented endpoint return
             return access_info, response.get("athlete")
         else:
             return access_info

--- a/src/stravalib/tests/integration/test_client.py
+++ b/src/stravalib/tests/integration/test_client.py
@@ -3,6 +3,7 @@ import json
 import os
 import warnings
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
 import responses
@@ -1082,3 +1083,87 @@ def test_get_activity_kudos(mock_strava_api, client):
     assert isinstance(kudoer_list[0], SummaryAthlete)
     assert len(kudoer_list) == 2
     assert kudoer_list[0].lastname == "Doe"
+
+
+@pytest.fixture
+def raw_exchange_response():
+    """Expected response from the protocol exchange_code_for_token method."""
+    return (
+        {
+            "access_token": "123456",
+            "refresh_token": "789sdf987",
+            "expires_at": 1732417459,
+        },
+        {
+            "id": 10295934,
+            "username": "foo_bar",
+            "resource_state": 2,
+            "firstname": "Foo",
+            "lastname": "Bar",
+            "bio": "A bio",
+            "city": "City",
+            "state": "State",
+            "country": "Country",
+            "sex": "F",
+            "premium": True,
+            "summit": True,
+        },
+    )
+
+
+@patch("stravalib.protocol.ApiV3.exchange_code_for_token")
+def test_exchange_code_for_token_athlete(
+    mock_request, client, raw_exchange_response
+):
+    """If a user requests athlete data, then it should be returned as a
+    SummaryAthlete object."""
+    mock_request.return_value = raw_exchange_response
+
+    result = client.exchange_code_for_token(
+        client_id=123,
+        client_secret="secret",
+        code="temp_code",
+        return_athlete=True,
+    )
+
+    assert result[0]["access_token"] == "123456"
+    assert len(result) == 2
+
+
+@patch("stravalib.protocol.ApiV3.exchange_code_for_token")
+def test_exchange_code_for_token_missing_athlete(
+    mock_request, client, raw_exchange_response
+):
+    """If a user requests athlete data, then it should be returned as a
+    SummaryAthlete object."""
+    mock_request.return_value = (raw_exchange_response[0], None)
+
+    with pytest.warns(UserWarning, match="Athlete data validation failed"):
+        result = client.exchange_code_for_token(
+            client_id=123,
+            client_secret="secret",
+            code="temp_code",
+            return_athlete=True,
+        )
+
+    assert result["access_token"] == "123456"
+
+
+@patch("stravalib.protocol.ApiV3.exchange_code_for_token")
+def test_exchange_code_for_token_no_athlete(
+    mock_request, client, raw_exchange_response
+):
+    """Make sure that when athlete itn's requested, it only returns
+    the authentication AccessInfo typed dict."""
+    # Protocol shouldn't return a tuple if athlete=False
+    mock_request.return_value = raw_exchange_response[0]
+
+    result = client.exchange_code_for_token(
+        client_id=123,
+        client_secret="secret",
+        code="temp_code",
+        return_athlete=False,
+    )
+
+    assert result["access_token"] == "123456"
+    assert isinstance(result, dict)

--- a/src/stravalib/tests/integration/test_client.py
+++ b/src/stravalib/tests/integration/test_client.py
@@ -1115,11 +1115,11 @@ def test_get_activity_kudos(mock_strava_api, client):
 
 @patch("stravalib.protocol.ApiV3.exchange_code_for_token")
 def test_exchange_code_for_token_athlete(
-    mock_request, client, raw_exchange_response
+    mock_protocol_exchange_code, client, raw_exchange_response
 ):
     """If a user requests athlete data, then it should be returned as a
     SummaryAthlete object."""
-    mock_request.return_value = raw_exchange_response
+    mock_protocol_exchange_code.return_value = raw_exchange_response
 
     access_info, summary_athlete = client.exchange_code_for_token(
         client_id=123,
@@ -1134,42 +1134,37 @@ def test_exchange_code_for_token_athlete(
 
 @patch("stravalib.protocol.ApiV3.exchange_code_for_token")
 def test_exchange_code_for_token_missing_athlete(
-    mock_request, client, raw_exchange_response
+    mock_protocol_exchange_code, client, raw_exchange_response
 ):
     """If athlete=True but Strava modifies the api response and athlete return
     is None client should only return AccessInfo object"""
-    mock_request.return_value = (raw_exchange_response[0], None)
-    access_info = client.exchange_code_for_token(
+    mock_protocol_exchange_code.return_value = (raw_exchange_response[0], None)
+    access_info, athlete = client.exchange_code_for_token(
         client_id=123,
         client_secret="secret",
         code="temp_code",
         return_athlete=True,
     )
 
-    result = client.exchange_code_for_token(
-        client_id=123,
-        client_secret="secret",
-        code="temp_code",
-        return_athlete=True,
-    )
-
-    assert result["access_token"] == "123456"
+    assert athlete is None
+    assert access_info["access_token"] == "123456"
 
 
 @patch("stravalib.protocol.ApiV3.exchange_code_for_token")
 def test_exchange_code_for_token_no_athlete(
-    mock_request, client, raw_exchange_response
+    mock_protocol_exchange_code, client, raw_exchange_response
 ):
     """When athlete isn't True, only return AccessInfo Typed Dict."""
-    # Protocol shouldn't return a tuple if athlete=False
-    mock_request.return_value = raw_exchange_response[0]
+    mock_protocol_exchange_code.return_value = raw_exchange_response
 
-    result = client.exchange_code_for_token(
+    access_info = client.exchange_code_for_token(
         client_id=123,
         client_secret="secret",
         code="temp_code",
         return_athlete=False,
     )
 
-    assert result["access_token"] == "123456"
-    assert isinstance(result, dict)
+    assert (
+        access_info["access_token"] == raw_exchange_response[0]["access_token"]
+    )
+    assert isinstance(access_info, dict)

--- a/src/stravalib/tests/integration/test_client.py
+++ b/src/stravalib/tests/integration/test_client.py
@@ -954,7 +954,9 @@ def test_get_segment_efforts(client, mock_strava_api):
     """Test that endpoint returns data as expected."""
     mock_strava_api.get("/segment_efforts", n_results=4)
 
-    efforts = list(client.get_segment_efforts(segment_id=2345, athlete_id=12345))
+    efforts = list(
+        client.get_segment_efforts(segment_id=2345, athlete_id=12345)
+    )
 
     assert len(efforts) == 4
     assert efforts[0].name == "Alpe d'Huez"
@@ -1119,32 +1121,37 @@ def test_exchange_code_for_token_athlete(
     SummaryAthlete object."""
     mock_request.return_value = raw_exchange_response
 
-    result = client.exchange_code_for_token(
+    access_info, summary_athlete = client.exchange_code_for_token(
         client_id=123,
         client_secret="secret",
         code="temp_code",
         return_athlete=True,
     )
 
-    assert result[0]["access_token"] == "123456"
-    assert len(result) == 2
+    assert access_info["access_token"] == "123456"
+    assert summary_athlete.firstname == "Foo"
 
 
 @patch("stravalib.protocol.ApiV3.exchange_code_for_token")
 def test_exchange_code_for_token_missing_athlete(
     mock_request, client, raw_exchange_response
 ):
-    """If athlete=True but strava modifies the api response and athlete return
-    is None, raise a warning."""
+    """If athlete=True but Strava modifies the api response and athlete return
+    is None client should only return AccessInfo object"""
     mock_request.return_value = (raw_exchange_response[0], None)
+    access_info = client.exchange_code_for_token(
+        client_id=123,
+        client_secret="secret",
+        code="temp_code",
+        return_athlete=True,
+    )
 
-    with pytest.warns(UserWarning, match="Athlete data validation failed"):
-        result = client.exchange_code_for_token(
-            client_id=123,
-            client_secret="secret",
-            code="temp_code",
-            return_athlete=True,
-        )
+    result = client.exchange_code_for_token(
+        client_id=123,
+        client_secret="secret",
+        code="temp_code",
+        return_athlete=True,
+    )
 
     assert result["access_token"] == "123456"
 

--- a/src/stravalib/tests/unit/test_protocol_auth.py
+++ b/src/stravalib/tests/unit/test_protocol_auth.py
@@ -58,11 +58,12 @@ def test_exchange_code_for_token_no_athlete(
     api_instance = ApiV3()
     mock_request.return_value = mock_token_exchange_response
 
-    result = api_instance.exchange_code_for_token(
+    access_info, athlete_info = api_instance.exchange_code_for_token(
         client_id=123,
         client_secret="secret",
         code="auth_code",
     )
 
-    assert len(result) == 3
-    assert result["access_token"] == "mock_access_token"
+    assert athlete_info is None
+    assert len(access_info) == 3
+    assert access_info["access_token"] == "mock_access_token"

--- a/src/stravalib/tests/unit/test_protocol_auth.py
+++ b/src/stravalib/tests/unit/test_protocol_auth.py
@@ -41,15 +41,15 @@ def test_exchange_code_for_token_athlete(
     api_instance = ApiV3()
     mock_request.return_value = mock_token_exchange_response
 
-    result = api_instance.exchange_code_for_token(
+    exchange_response, athlete = api_instance.exchange_code_for_token(
         client_id=123,
         client_secret="secret",
         code="auth_code",
         return_athlete=True,
     )
 
-    # If athlete info is requested, return should be a tuple of 2 items
-    assert len(result) == 2
+    assert exchange_response["access_token"] == "mock_access_token"
+    assert athlete["id"] == 12345
 
 
 @patch("stravalib.protocol.ApiV3._request")

--- a/src/stravalib/tests/unit/test_protocol_auth.py
+++ b/src/stravalib/tests/unit/test_protocol_auth.py
@@ -1,0 +1,70 @@
+from unittest.mock import patch
+
+import pytest
+
+from stravalib.protocol import ApiV3
+
+
+@pytest.fixture
+def mock_token_exchange_response():
+    """A fixture that mocks a token exchange response that includes
+    the athlete info"""
+    return {
+        "access_token": "mock_access_token",
+        "refresh_token": "mock_refresh_token",
+        "expires_at": 1234567890,
+        "athlete": {
+            "id": 12345,
+            "username": "mock_athlete",
+            "firstname": "Mock",
+            "lastname": "Athlete",
+        },
+    }
+
+
+@pytest.fixture
+def mock_token_refresh_response():
+    """A fixture that mocks the response for a refreshed token."""
+    return {
+        "access_token": "new_mock_access_token",
+        "refresh_token": "new_mock_refresh_token",
+        "expires_at": 9876543210,
+    }
+
+
+@patch("stravalib.protocol.ApiV3._request")
+def test_exchange_code_for_token_athlete(
+    mock_request, mock_token_exchange_response
+):
+    # with patch("stravalib.protocol.ApiV3._request") as mock_request:
+    # Set _request to return the raw dictionary
+    api_instance = ApiV3()
+    mock_request.return_value = mock_token_exchange_response
+
+    result = api_instance.exchange_code_for_token(
+        client_id=123,
+        client_secret="secret",
+        code="auth_code",
+        return_athlete=True,
+    )
+
+    # If athlete info is requested, return should be a tuple of 2 items
+    assert len(result) == 2
+
+
+@patch("stravalib.protocol.ApiV3._request")
+def test_exchange_code_for_token_no_athlete(
+    mock_request, mock_token_exchange_response
+):
+    api_instance = ApiV3()
+    mock_request.return_value = mock_token_exchange_response
+
+    result = api_instance.exchange_code_for_token(
+        client_id=123,
+        client_secret="secret",
+        code="auth_code",
+    )
+
+    # If athlete info is requested, return should be a dict of 3 items
+    assert len(result) == 3
+    assert result["access_token"] == "mock_access_token"

--- a/src/stravalib/tests/unit/test_protocol_auth.py
+++ b/src/stravalib/tests/unit/test_protocol_auth.py
@@ -36,7 +36,6 @@ def mock_token_refresh_response():
 def test_exchange_code_for_token_athlete(
     mock_request, mock_token_exchange_response
 ):
-    # with patch("stravalib.protocol.ApiV3._request") as mock_request:
     # Set _request to return the raw dictionary
     api_instance = ApiV3()
     mock_request.return_value = mock_token_exchange_response
@@ -65,6 +64,5 @@ def test_exchange_code_for_token_no_athlete(
         code="auth_code",
     )
 
-    # If athlete info is requested, return should be a dict of 3 items
     assert len(result) == 3
     assert result["access_token"] == "mock_access_token"


### PR DESCRIPTION
closes #552

## Description

This ensures `exchange_code_for_token` returns the optional `SummaryAthlete` object if requested.
## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [ ] This is a infrastructure update (docs, ci, etc)
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [X] Yes
- [ ] No, i'd like some help with tests
- [ ] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.
