### PR TITLE
fix: update codecov in build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -58,7 +58,7 @@ jobs:
           nox -s tests-${{ matrix.python-version }}
       - name: Upload coverage to Codecov
         if: ${{ matrix.os == 'ubuntu-latest' &&  matrix.python-version == '3.11'}}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true


### PR DESCRIPTION
This is a small patch pr that just updates the version of the codecov action we're using as I'm noting some flakiness in cov reports. I'll merge this .