### PR TITLE
fix: add trusted publisher setup to stravalib

### DIFF
--- a/.github/workflows/push-pypi.yml
+++ b/.github/workflows/push-pypi.yml
@@ -6,10 +6,11 @@ on:
     branches:
       - main
 jobs:
-  build-publish:
+  build:
     runs-on: ubuntu-latest
     # Only run build action on base repo - not forks
     if: github.repository_owner == 'stravalib'
+    environment: build
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,7 +25,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -42,9 +43,34 @@ jobs:
       - name: Check the archives
         run: twine check dist/*
 
-      - name: Publish package to PyPI
-        # Only publish to real PyPI on release
-        if: github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@release/v1
+      # Store an artifact of the build to use in the publish step below
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
+          name: python-package-distributions
+          path: dist/
+
+  publish:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+
+        # Only publish to real PyPI on release
+    if: github.event_name == 'release'
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/stravalib
+      permissions:
+        id-token: write  # this permission is mandatory for pypi publishing
+      steps:
+        - name: Download all dists
+          uses: actions/download-artifact@v4
+          with:
+            name: python-package-distributions
+            path: dist/
+        - name: Publish package to PyPI
+          # Only publish to real PyPI on release
+          if: github.event_name == 'release'
+          uses: pypa/gh-action-pypi-publish@release/v1

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+### Fixed
+
+- Fix: Setup trusted publishing & enhance publish step security (@lwasser, #617)
+
 ## v2.2.0
 
 ### Added


### PR DESCRIPTION
closes #617


## Description

This pr describes and adds trusted publishing to stravalib. Right now we are publishing via a token. This is ok but token leaks are real AND trusted publishing is a more secure and preferred route to publishing. 

A few things left to do here

- [ ] document the slight change in the workflow - 
- [x] Setup trusted publisher in pypi

<img width="683" alt="Screenshot 2025-02-08 at 2 05 05 PM" src="https://github.com/user-attachments/assets/cb4f71d2-e2d7-4169-8640-935e6b4fcfc6" />- 


## Type of change

Select the statement best describes this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [x] This is a infrastructure update (docs, ci, etc)
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [x] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.
