### PR TITLE
chore(ci): narrow permissions used in actions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   build-doc:
     runs-on: ubuntu-latest
@@ -13,6 +15,9 @@ jobs:
       PYTHON-VERSION: "3.11"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 20
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,6 +11,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   build-test:
     name: Test Run (${{ matrix.python-version }}, ${{ matrix.os }})
@@ -26,6 +28,7 @@ jobs:
         with:
           # fetch more than the last single commit to help scm generate proper version
           fetch-depth: 20
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:

--- a/.github/workflows/check-strava-api.yml
+++ b/.github/workflows/check-strava-api.yml
@@ -5,12 +5,16 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   update-model:
     name: Update Model
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Fetch API
         run: curl https://developers.strava.com/swagger/swagger.json > src/stravalib/tests/resources/strava_swagger.json
       - name: Fetch API Schema

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: "read"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,6 +21,7 @@ jobs:
         with:
           # So scm can view previous commits
           fetch-depth: 100
+          persist-credentials: false
 
       # Need the tags so that setuptools-scm can form a valid version number
       - name: Fetch git tags

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -11,6 +11,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   mypy:
     name: Run mypy
@@ -20,6 +22,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 20
+          persist-credentials: false
       - name: Set up Python 3.11
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 - Add: allow silencing of warning about missing environment variables (@kevsteramp, @jsamoocha, #643)
 - Fix: Pin GHA dependencies throughout to optimize security (@miketheman, #645)
 - Fix: Update Dependabot config to also update GitHub Actions dependencies (@miketheman, #646)
+- Fix: Narrow permissions used in GitHub Actions workflows (@miketheman, #648)
 
 ## v2.3.0
 


### PR DESCRIPTION
## Description

Narrows permissions used in GitHub Actions to only what is needed to run.

Refs: https://docs.zizmor.sh/audits/#excessive-permissions

## Type of change

Select the statement best describes this pull request.

- [x] This is a infrastructure update (docs, ci, etc)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [x] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.
