### PR TITLE
Fix/job permissions

### DIFF
--- a/.github/workflows/check-strava-api.yml
+++ b/.github/workflows/check-strava-api.yml
@@ -5,14 +5,15 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   update-model:
     name: Update Model
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/check-strava-api.yml
+++ b/.github/workflows/check-strava-api.yml
@@ -5,7 +5,9 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   update-model:

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Unreleased
+- Fix: Adds necessary permissions for update-model job (@jsamoocha, #654)
 
 ### Fixed
 - Fix: Numerous documentation fixes (@lwasser, #651)


### PR DESCRIPTION
closes #654 

## Description

This PR adds explicit permissions to the update-model job so that it is allowed to push branches
and create PRs in case of a Strava API change.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This is a infrastructure update (docs, ci, etc)

## Does your PR include tests

- [X] This change doesn't require tests

## Did you include your contribution to the change log?

- [X] Yes, `changelog.md` is up-to-date.