### PR TITLE
fix: send update_activity payload as JSON body (#716)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 - Add: Support for Python 3.14 (@lwasser)
 
 ### Fixed
+- Fix: Send `update_activity` payload as a JSON body so boolean fields (e.g. `hide_from_home`, `commute`, `trainer`) are applied correctly by the Strava API (@jsamoocha, #716)
 - Fix: Remove false warning about response headers on authentication calls (@BPR02, #667)
 - Fix: drop support for Python 3.10 (@lwasser, #687)
 - Fix: Improve response header handling (@BPR02, #664)

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -992,42 +992,35 @@ class Client:
 
         """
 
-        # Convert the kwargs into a params dict
-        params: dict[str, Any] = {}
-
-        if name is not None:
-            params["name"] = name
-
+        # These params are no longer supported by the Strava API. They are
+        # still accepted for backward compatibility, but are not sent.
         if private is not None:
             warn_param_unsupported("private")
-            params["private"] = int(private)
-
-        if commute is not None:
-            params["commute"] = int(commute)
-
-        if trainer is not None:
-            params["trainer"] = int(trainer)
-
-        if gear_id is not None:
-            params["gear_id"] = gear_id
-
-        if description is not None:
-            params["description"] = description
-
         if device_name is not None:
             warn_param_unsupported("device_name")
-            params["device_name"] = device_name
 
-        if hide_from_home is not None:
-            params["hide_from_home"] = int(hide_from_home)
+        # Build a typed payload that is sent as a JSON request body. Using
+        # UpdatableActivity ensures values are serialized as proper JSON types
+        # (e.g. booleans as ``true``/``false`` rather than ``1``/``0``), which
+        # the Strava API requires to apply the update. See GH issue #716.
+        body = strava_model.UpdatableActivity(
+            name=name,
+            description=description,
+            commute=commute,
+            trainer=trainer,
+            # gear_id is documented as alphanumeric; coerce to str so an int
+            # passed via the (legacy) signature is still accepted.
+            gear_id=None if gear_id is None else str(gear_id),
+            hide_from_home=hide_from_home,
+        ).model_dump(mode="json", exclude_none=True)
 
-        # Validate sport and activity types
-        params = self._validate_activity_type(
-            params, activity_type, sport_type
-        )
+        # Validate sport and activity types, adding them to the payload
+        body = self._validate_activity_type(body, activity_type, sport_type)
 
         raw_activity = self.protocol.put(
-            "/activities/{activity_id}", activity_id=activity_id, **params
+            "/activities/{activity_id}",
+            activity_id=activity_id,
+            body=body,
         )
 
         return model.DetailedActivity.model_validate(

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -941,7 +941,7 @@ class Client:
         private: bool | None = None,
         commute: bool | None = None,
         trainer: bool | None = None,
-        gear_id: int | None = None,
+        gear_id: str | None = None,
         device_name: str | None = None,
         hide_from_home: bool | None = None,
     ) -> model.DetailedActivity:
@@ -970,7 +970,7 @@ class Client:
             Whether the activity is a commute.
         trainer : bool, default=None
             Whether this is a trainer activity.
-        gear_id : int, default=None
+        gear_id : str, default=None
             Alphanumeric ID of gear (bike, shoes) used on this activity.
         description : str, default=None
             Description for the activity.
@@ -1008,9 +1008,7 @@ class Client:
             description=description,
             commute=commute,
             trainer=trainer,
-            # gear_id is documented as alphanumeric; coerce to str so an int
-            # passed via the (legacy) signature is still accepted.
-            gear_id=None if gear_id is None else str(gear_id),
+            gear_id=gear_id,
             hide_from_home=hide_from_home,
         ).model_dump(mode="json", exclude_none=True)
 

--- a/src/stravalib/protocol.py
+++ b/src/stravalib/protocol.py
@@ -163,6 +163,7 @@ class ApiV3(metaclass=abc.ABCMeta):
         url: str,
         params: dict[str, Any] | None = None,
         files: dict[str, SupportsRead[str | bytes]] | None = None,
+        body: dict[str, Any] | None = None,
         method: RequestMethod = "GET",
         check_for_errors: bool = True,
     ) -> Any:
@@ -177,9 +178,14 @@ class ApiV3(metaclass=abc.ABCMeta):
         url : str
             The request URL.
         params : Dict[str,Any]
-            Request parameters
+            Request parameters sent as the URL query string.
         files : Dict[str,file]
             Dictionary of file name to file-like objects.
+        body : Dict[str,Any]
+            Request data sent as a JSON-encoded request body. Use this for
+            endpoints that expect a JSON payload (e.g. PUT) so that values
+            such as booleans are serialized as proper JSON types rather than
+            query-string strings.
         method : str
             The request method (GET/POST/etc.)
         check_for_errors : bool
@@ -216,7 +222,7 @@ class ApiV3(metaclass=abc.ABCMeta):
                 f"Invalid/unsupported request method specified: {method}"
             )
 
-        raw = requester(url, params=params)  # type: ignore[operator]
+        raw = requester(url, params=params, json=body)  # type: ignore[operator]
         # Rate limits are taken from HTTP response headers
         # https://developers.strava.com/docs/rate-limits/
         if "/oauth/" not in url:
@@ -626,7 +632,11 @@ class ApiV3(metaclass=abc.ABCMeta):
         )
 
     def put(
-        self, url: str, check_for_errors: bool = True, **kwargs: Any
+        self,
+        url: str,
+        check_for_errors: bool = True,
+        body: dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> Any:
         """Performs a generic PUT request for specified params, returning the
         response.
@@ -637,6 +647,10 @@ class ApiV3(metaclass=abc.ABCMeta):
             String representing url to access.
         check_for_errors: bool
             Whether to raise an error (or not)
+        body : dict, optional
+            Data to send as a JSON-encoded request body. Remaining keyword
+            arguments are used to format the URL and are sent as query-string
+            parameters.
 
         Returns
         -------
@@ -647,7 +661,11 @@ class ApiV3(metaclass=abc.ABCMeta):
         url = url.format(**kwargs)
         params = {k: v for k, v in kwargs.items() if k not in referenced}
         return self._request(
-            url, params=params, method="PUT", check_for_errors=check_for_errors
+            url,
+            params=params,
+            body=body,
+            method="PUT",
+            check_for_errors=check_for_errors,
         )
 
     def delete(

--- a/src/stravalib/tests/integration/test_client.py
+++ b/src/stravalib/tests/integration/test_client.py
@@ -377,7 +377,7 @@ def test_get_activity_streams_series_type_unofficial(mock_strava_api, client):
 
 
 @pytest.mark.parametrize(
-    "update_kwargs,expected_params,expected_warning,expected_exception",
+    "update_kwargs,expected_body,expected_warning,expected_exception",
     (
         ({}, {}, None, None),
         ({"activity_type": "Run"}, {"type": "run"}, DeprecationWarning, None),
@@ -388,18 +388,20 @@ def test_get_activity_streams_series_type_unofficial(mock_strava_api, client):
             None,
             None,
         ),
-        ({"private": True}, {"private": "1"}, DeprecationWarning, None),
-        ({"commute": True}, {"commute": "1"}, None, None),
-        ({"trainer": True}, {"trainer": "1"}, None, None),
+        # private is no longer supported by the API: warn but do not send it
+        ({"private": True}, {}, DeprecationWarning, None),
+        ({"commute": True}, {"commute": True}, None, None),
+        ({"trainer": True}, {"trainer": True}, None, None),
         ({"gear_id": "fb42"}, {"gear_id": "fb42"}, None, None),
         ({"description": "foo"}, {"description": "foo"}, None, None),
+        # device_name is no longer supported: warn but do not send it
         (
             {"device_name": "foo"},
-            {"device_name": "foo"},
+            {},
             DeprecationWarning,
             None,
         ),
-        ({"hide_from_home": False}, {"hide_from_home": "0"}, None, None),
+        ({"hide_from_home": False}, {"hide_from_home": False}, None, None),
         (
             {"name": "My awesome activity"},
             {"name": "My awesome activity"},
@@ -412,7 +414,7 @@ def test_update_activity(
     mock_strava_api,
     client,
     update_kwargs,
-    expected_params,
+    expected_body,
     expected_warning,
     expected_exception,
 ):
@@ -420,7 +422,8 @@ def test_update_activity(
 
     def _call_update_activity():
         _ = client.update_activity(activity_id, **update_kwargs)
-        assert mock_strava_api.calls[-1].request.params == expected_params
+        request = mock_strava_api.calls[-1].request
+        assert json.loads(request.body) == expected_body
 
     if expected_exception:
         with pytest.raises(expected_exception):


### PR DESCRIPTION
closes #716

## Description

- Ensures correct json serialization of boolean fields of update activity request
- Corrects `gear_id` type in `update_activity()` API method

## Type of change

Select the statement best describes this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [x] Yes

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.
