### PR TITLE
fix: improve license metadata (PEP 639), resolve deprecation warnings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- fix: improve license metadata (PEP 639), resolve deprecation warnings (@mwtoews, #728)
+
 ## v2.5.0
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=77", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -23,7 +23,7 @@ description = "A Python package that makes it easy to access and download data f
 keywords = ["strava", "running", "cycling", "athletes"]
 readme = "README.md"
 dynamic = ["version"]
-license = { text = "Apache 2.0 License" }
+license = "Apache-2.0"
 authors = [{ name = "Hans Lellelid", email = "hans@xmpl.org" }]
 maintainers = [
   { name = "Leah Wasser" },
@@ -38,7 +38,6 @@ classifiers = [
   "Programming Language :: Python",
   "Intended Audience :: Science/Research",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: Apache Software License",
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Topic :: Scientific/Engineering",


### PR DESCRIPTION
## Description

This PR applies [PEP 639](https://peps.python.org/pep-0639/) to improve license metadata, while also resolving deprecation warnings while building this package with recent versions of tools (e.g. `uv build`).

- Changes license to use valid SPDX identifier [`Apache-2.0`](https://spdx.org/licenses/Apache-2.0.html); the table structure is deprecated
- Remove license classifier, as it is deprecated

These changes require setuptools >= 77 ([ref](https://setuptools.pypa.io/en/stable/history.html#v77-0-0)).

## Type of change

Select the statement best describes this pull request.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Other (please describe): metadata

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, I'd like some help with tests
- [X] This change doesn't require tests

## Did you include your contribution to the change log?

- [ ] Yes, `changelog.md` is up-to-date.

Is this type of change needed here?
