### PR TITLE
feat: warn about the Strava API changes of 1 September 2026

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,10 +4,12 @@
 
 ### Added
 - Add: `exc.ApplicationInactive`, raised on a 403 response that reports an inactive Strava application, with a message that says how to reactivate it (@jsamoocha, #730)
+- Add: Warnings about the Strava API changes of September 1, 2026. `get_club_members`, `get_club_activities`, and `get_club_admins` emit a `DeprecationWarning`, because Strava removes those endpoints. `explore_segments` emits a `FutureWarning`, because Strava limits that endpoint to the Extended Access Tier (@jsamoocha, #736)
 
 ### Fixed
 - Fix: Prevent an `AttributeError` in the API error handler when Strava returns a JSON body that is not an object (@jsamoocha, #730)
 - Fix: improve license metadata (PEP 639), resolve deprecation warnings (@mwtoews, #728)
+- Fix: `explore_segments` now shows the bounds you supplied when it rejects them. The message showed the literal text `{0!r}` (@jsamoocha, #736)
 
 ### Changed
 - Change: Send the access token in the `Authorization: Bearer` request header instead of the `access_token` URL query parameter, as advised by RFC 6750 and documented by Strava (@ragusa87, @jsamoocha, #733)

--- a/docs/get-started/activities.md
+++ b/docs/get-started/activities.md
@@ -295,6 +295,14 @@ To get activities starting with the oldest first, specify a value for the `after
 
 You can also use stravalib to access activities associated with a club. To do this, use {py:func}`stravalib.client.Client.get_club_activities`.
 
+:::{warning}
+Strava removes the Club Activities endpoint on September 1, 2026. After that
+date, `get_club_activities` fails. The same applies to
+{py:func}`stravalib.client.Client.get_club_members` and
+{py:func}`stravalib.client.Client.get_club_admins`. See the
+[Strava V3 API changelog](https://developers.strava.com/docs/changelog/).
+:::
+
 <!-- (TODO)
 ## Create and update activities
 

--- a/docs/reference/client.rst
+++ b/docs/reference/client.rst
@@ -45,6 +45,15 @@ Athlete methods
 
 Club related methods
 --------------------
+
+.. warning::
+
+   Strava removes the Club Members, Club Activities, and Club Admins
+   endpoints on September 1, 2026. ``Client.get_club_members``,
+   ``Client.get_club_activities``, and ``Client.get_club_admins`` fail after
+   that date. See the `Strava V3 API changelog
+   <https://developers.strava.com/docs/changelog/>`_.
+
 .. autosummary::
    :toctree: api/
 
@@ -53,6 +62,7 @@ Club related methods
    Client.get_club
    Client.get_club_members
    Client.get_club_activities
+   Client.get_club_admins
 
 Activity related methods
 -------------------------
@@ -72,6 +82,15 @@ Activity related methods
 
 Segment related methods
 -------------------------
+
+.. warning::
+
+   Strava limits the Explore Segments endpoint to the Extended Access Tier on
+   September 1, 2026. Standard Tier is the default for every application, so
+   ``Client.explore_segments`` fails after that date unless Strava approves
+   your application for the Extended Access Tier. See the `Strava V3 API
+   changelog <https://developers.strava.com/docs/changelog/>`_.
+
 .. autosummary::
    :toctree: api/
 

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -34,6 +34,8 @@ from stravalib import exc, model, strava_model, unit_helper
 from stravalib.exc import (
     ActivityPhotoUploadNotSupported,
     warn_attribute_unofficial,
+    warn_method_removal,
+    warn_method_restricted,
     warn_method_unofficial,
     warn_param_deprecation,
     warn_param_unofficial,
@@ -50,6 +52,12 @@ ActivityType = str
 SportType = str
 StreamType = str
 PhotoMetadata = Any
+
+#: Date on which Strava removes the Club Activities, Club Members, and Club
+#: Admins endpoints, and limits the Explore Segments endpoint to the Extended
+#: Access Tier.
+STRAVA_API_CHANGE_DATE = "September 1, 2026"
+STRAVA_API_CHANGELOG_URL = "https://developers.strava.com/docs/changelog/"
 
 
 class Client:
@@ -665,7 +673,20 @@ class Client:
         class:`BatchedResultsIterator`
             An iterator of :class:`stravalib.model.Athlete` objects.
 
+        Warns
+        -----
+        DeprecationWarning
+            Strava removes the Club Members endpoint. The warning gives the
+            removal date, after which calls to this method fail. See
+            https://developers.strava.com/docs/changelog/.
+
         """
+        warn_method_removal(
+            "get_club_members",
+            STRAVA_API_CHANGE_DATE,
+            STRAVA_API_CHANGELOG_URL,
+        )
+
         result_fetcher = functools.partial(
             self.protocol.get, "/clubs/{id}/members", id=club_id
         )
@@ -696,7 +717,20 @@ class Client:
         class:`BatchedResultsIterator`
             An iterator of :class:`stravalib.model.ClubActivity` objects.
 
+        Warns
+        -----
+        DeprecationWarning
+            Strava removes the Club Activities endpoint. The warning gives the
+            removal date, after which calls to this method fail. See
+            https://developers.strava.com/docs/changelog/.
+
         """
+        warn_method_removal(
+            "get_club_activities",
+            STRAVA_API_CHANGE_DATE,
+            STRAVA_API_CHANGELOG_URL,
+        )
+
         result_fetcher = functools.partial(
             self.protocol.get, "/clubs/{id}/activities", id=club_id
         )
@@ -727,7 +761,19 @@ class Client:
         class:`BatchedResultsIterator`
             An iterator of :class:`stravalib.model.SummaryAthlete` objects.
 
+        Warns
+        -----
+        DeprecationWarning
+            Strava removes the Club Admins endpoint. The warning gives the
+            removal date, after which calls to this method fail. See
+            https://developers.strava.com/docs/changelog/.
+
         """
+        warn_method_removal(
+            "get_club_admins",
+            STRAVA_API_CHANGE_DATE,
+            STRAVA_API_CHANGELOG_URL,
+        )
 
         result_fetcher = functools.partial(
             self.protocol.get, "/clubs/{id}/admins", id=club_id
@@ -1570,6 +1616,15 @@ class Client:
         :class:`list`
             An list of :class:`stravalib.model.Segment`.
 
+        Warns
+        -----
+        FutureWarning
+            Strava limits the Explore Segments endpoint to the Extended Access
+            Tier. Standard Tier is the default for every application. The
+            warning gives the date, after which calls from an application in
+            the Standard Tier fail. See
+            https://developers.strava.com/docs/changelog/.
+
         """
         if len(bounds) == 2:
             bounds = (
@@ -1580,8 +1635,8 @@ class Client:
             )
         elif len(bounds) != 4:
             raise ValueError(
-                "Invalid bounds specified: {0!r}. Must be tuple of 4 float "
-                "values or tuple of 2 (lat,lon) tuples."
+                f"Invalid bounds specified: {bounds!r}. Must be tuple of 4 "
+                "float values or tuple of 2 (lat,lon) tuples."
             )
 
         params: dict[str, Any] = {"bounds": ",".join(str(b) for b in bounds)}
@@ -1598,6 +1653,12 @@ class Client:
             params["min_cat"] = min_cat
         if max_cat is not None:
             params["max_cat"] = max_cat
+
+        warn_method_restricted(
+            "explore_segments",
+            STRAVA_API_CHANGE_DATE,
+            STRAVA_API_CHANGELOG_URL,
+        )
 
         raw = self.protocol.get("/segments/explore", **params)
         return [

--- a/src/stravalib/exc.py
+++ b/src/stravalib/exc.py
@@ -143,6 +143,59 @@ def warn_method_deprecation(
     )
 
 
+def warn_method_removal(
+    method_name: str, removal_date: str, alt_url: str | None = None
+) -> None:
+    """Warn that Strava removes the endpoint used by a method.
+
+    Parameters
+    ----------
+    method_name : str
+        Name of the method that calls the endpoint.
+    removal_date : str
+        Date on which Strava removes the endpoint.
+    alt_url : str, optional
+        Link to more information about the change.
+    """
+    alt_support_msg = (
+        f" See {alt_url} for more information." if alt_url else ""
+    )
+    warnings.warn(
+        f'The "{method_name}" method uses a Strava API endpoint that Strava '
+        f"removes on {removal_date}. Calls to this method fail after that "
+        f"date.{alt_support_msg}",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+def warn_method_restricted(
+    method_name: str, restriction_date: str, alt_url: str | None = None
+) -> None:
+    """Warn that Strava limits the endpoint used by a method to a higher tier.
+
+    Parameters
+    ----------
+    method_name : str
+        Name of the method that calls the endpoint.
+    restriction_date : str
+        Date on which Strava applies the restriction.
+    alt_url : str, optional
+        Link to more information about the change.
+    """
+    alt_support_msg = (
+        f" See {alt_url} for more information." if alt_url else ""
+    )
+    warnings.warn(
+        f'The "{method_name}" method uses a Strava API endpoint that Strava '
+        f"restricts to the Extended Access Tier on {restriction_date}. Calls "
+        f"from an application in the Standard Tier fail after that "
+        f"date.{alt_support_msg}",
+        FutureWarning,
+        stacklevel=3,
+    )
+
+
 def warn_param_unsupported(param_name: str) -> None:
     warnings.warn(
         f'The "{param_name}" parameter is unsupported by the Strava API. It has no '

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -621,6 +621,13 @@ class MetaClub(strava_model.MetaClub, BoundClientEntity):
         -------
         List
             A list of club members stored as Athlete objects.
+
+        Warns
+        -----
+        DeprecationWarning
+            Strava removes the Club Members endpoint. The warning gives the
+            removal date, after which this property fails. See
+            https://developers.strava.com/docs/changelog/.
         """
         assert self.bound_client is not None, "Bound client is not set."
         return self.bound_client.get_club_members(self.id)
@@ -634,6 +641,13 @@ class MetaClub(strava_model.MetaClub, BoundClientEntity):
         -------
         Iterator
             An iterator of Activity objects representing club activities.
+
+        Warns
+        -----
+        DeprecationWarning
+            Strava removes the Club Activities endpoint. The warning gives the
+            removal date, after which this property fails. See
+            https://developers.strava.com/docs/changelog/.
         """
         assert self.bound_client is not None, "Bound client is not set."
         return self.bound_client.get_club_activities(self.id)

--- a/src/stravalib/tests/integration/test_client.py
+++ b/src/stravalib/tests/integration/test_client.py
@@ -299,6 +299,45 @@ def test_get_club_admins(mock_strava_api, client):
     assert admins[0].firstname == "Jane"
 
 
+@pytest.mark.parametrize(
+    "method_name",
+    ("get_club_members", "get_club_activities", "get_club_admins"),
+)
+def test_retired_club_endpoints_warn(mock_strava_api, client, method_name):
+    """Strava removes these Club endpoints on September 1, 2026. Warn the
+    user when the method is called, before any request is made.
+
+    No endpoint is registered on the mock. The mock still intercepts every
+    request, so an eager fetch fails here instead of reaching Strava.
+    """
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=(
+            f'"{method_name}" method uses a Strava API endpoint that Strava '
+            "removes on September 1, 2026"
+        ),
+    ):
+        getattr(client, method_name)(42)
+
+    assert len(mock_strava_api.calls) == 0
+
+
+@pytest.mark.parametrize("property_name", ("members", "activities"))
+def test_retired_club_properties_warn(mock_strava_api, client, property_name):
+    """The lazy properties of a club delegate to the retired client methods,
+    so they warn too."""
+
+    mock_strava_api.get("/clubs/{id}", response_update={"id": 42})
+    club = client.get_club(42)
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="Strava API endpoint that Strava removes on September 1, 2026",
+    ):
+        getattr(club, property_name)
+
+
 def test_get_activity_zones(mock_strava_api, client, zone_response):
     """Returns an activities associated zone (related to heart rate and power)
 
@@ -1262,6 +1301,35 @@ def test_explore_segments(mock_strava_api, client):
     segment_list = client.explore_segments((1, 2, 3, 4))
     assert len(segment_list) == 1
     assert segment_list[0].name == "Hawk Hill"
+
+
+def test_explore_segments_restricted_warning(mock_strava_api, client):
+    """Strava limits this endpoint to the Extended Access Tier on
+    September 1, 2026. The method still works, so the warning is a
+    FutureWarning."""
+
+    mock_strava_api.get("/segments/explore")
+
+    with pytest.warns(
+        FutureWarning,
+        match=(
+            '"explore_segments" method uses a Strava API endpoint that Strava '
+            "restricts to the Extended Access Tier on September 1, 2026"
+        ),
+    ):
+        client.explore_segments((1, 2, 3, 4))
+
+
+def test_explore_segments_invalid_bounds(client, recwarn):
+    """Invalid input is rejected before the endpoint warning fires, and the
+    error message shows the bounds the caller passed."""
+
+    with pytest.raises(
+        ValueError, match=r"Invalid bounds specified: \(1, 2, 3\)"
+    ):
+        client.explore_segments((1, 2, 3))
+
+    assert not [w for w in recwarn if w.category is FutureWarning]
 
 
 def test_get_activity_kudos(mock_strava_api, client):


### PR DESCRIPTION
closes #736

_The text above will ensure the issue will be closed when this PR is merged_

## Description

On 1 September 2026 Strava removes three Club endpoints and limits a fourth
endpoint to the Extended Access Tier. Standard Tier is the default for every
application, so all four calls stop working for most stravalib users on that
date. This PR warns users before their code breaks.

| Method | Warning | Why |
| --- | --- | --- |
| `Client.get_club_members` | `DeprecationWarning` | Strava removes the endpoint |
| `Client.get_club_activities` | `DeprecationWarning` | Strava removes the endpoint |
| `Client.get_club_admins` | `DeprecationWarning` | Strava removes the endpoint |
| `Client.explore_segments` | `FutureWarning` | The endpoint stays, but only for approved applications |

### Decisions worth a look

**Two new helpers in `exc.py` instead of `warn_method_deprecation`.** The issue
suggested reusing that helper. It needs an `alternative` argument and prints
"Instead, you can use X", which is wrong for an endpoint with no replacement.
The new `warn_method_removal` and `warn_method_restricted` put the date in the
message and link to the Strava changelog:

> The "get_club_members" method uses a Strava API endpoint that Strava removes
> on September 1, 2026. Calls to this method fail after that date. See
> https://developers.strava.com/docs/changelog/ for more information.

**All four methods keep working.** The issue asks whether the three retired
methods should later raise a clear error or be removed. This PR does not answer
that. It adds warnings only. The question stays open for a future release.

**The warning fires at call time, not at iteration time.** The three club
methods return a lazy `BatchedResultsIterator`. The warn call sits before the
iterator is built, so a user who never consumes the iterator still gets told.

**The lazy properties warn too.** `MetaClub.members` and `MetaClub.activities`
delegate to the retired client methods. Note that the warning is attributed to
`stravalib/model.py` rather than to user code, because `stacklevel` is fixed at
3. The warning still displays. Threading a `stacklevel` parameter through for
two properties did not seem worth it.

**`explore_segments` warns only when the call would really reach the endpoint.**
The warn call sits after every input check, so a call with bad input raises
`ValueError` without warning about a 2026 deadline it will never reach.

### Drive-by fix

`explore_segments` printed the literal text `{0!r}` when it rejected invalid
bounds. The string had no `f` prefix and nothing called `.format` on it. It now
shows the bounds the caller passed:

```
Invalid bounds specified: (1, 2, 3). Must be tuple of 4 float values or tuple of 2 (lat,lon) tuples.
```

### Docs

Warning blocks in the Club and Segment sections of `docs/reference/client.rst`,
and in `docs/get-started/activities.md`, which still recommends
`get_club_activities`. `Client.get_club_admins` was missing from the reference
autosummary and is now listed.

The date is not repeated in the API docstrings. They say the warning gives the
date and link to the changelog, so a moved deadline does not leave stale prose
in six docstrings.

## Type of change

Select the statement best describes this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [ ] This is a infrastructure update (docs, ci, etc)
- [ ] Other (please describe)

The main change adds warnings. The `explore_segments` error message fix is a
small bug fix included here because it is in a method this PR already touches.
Documentation is updated in this PR.

## Does your PR include tests

- [x] Yes
- [ ] No, I'd like some help with tests
- [ ] This change doesn't require tests

Five new tests, 269 passing in total:

- `test_retired_club_endpoints_warn` asserts the message for each of the three
  club methods, and asserts no request is made. It takes `mock_strava_api` with
  no endpoint registered, so an eager fetch fails against the mock instead of
  reaching Strava.
- `test_retired_club_properties_warn` covers the `MetaClub` lazy properties.
- `test_explore_segments_restricted_warning` asserts the `FutureWarning`.
- `test_explore_segments_invalid_bounds` asserts the new error message and that
  no warning fires before the input check. Verified as a real regression check:
  with the warn call moved back above the validation, this test fails.

`mypy`, `black`, `ruff`, and `codespell` are clean.

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.
