### PR TITLE
Bump to v2.6.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v2.6.0
+
 ### Added
 - Add: `exc.ApplicationInactive`, raised on a 403 response that reports an inactive Strava application, with a message that says how to reactivate it (@jsamoocha, #730)
 - Add: Warnings about the Strava API changes of September 1, 2026. `get_club_members`, `get_club_activities`, and `get_club_admins` emit a `DeprecationWarning`, because Strava removes those endpoints. `explore_segments` emits a `FutureWarning`, because Strava limits that endpoint to the Extended Access Tier (@jsamoocha, #736)
@@ -16,6 +18,9 @@
 - Change: Send the token request parameters in a form-encoded request body instead of the URL query string, as required by RFC 6749 §2.3.1. The client secret, the authorization code, and the refresh token no longer reach the URL of a token request (@jsamoocha, #740)
 - Change: Send the `create_subscription` and `delete_subscription` parameters in a form-encoded request body instead of the URL query string, so the client secret no longer reaches the URL. Strava documents the body form for `create_subscription`; for `delete_subscription` the body form works but is undocumented, and the docstring says so. `list_subscriptions` still sends the credentials in the URL, because a GET that carries a body is rejected before it reaches Strava (@jsamoocha, #740)
 - Change: The request log line records parameter names instead of parameter values, so an application logging at INFO no longer writes its own client secret to disk (@jsamoocha, #740)
+
+### Contributors to this release
+@jsamoocha, @ragusa87, @mwtoews
 
 ## v2.5.0
 


### PR DESCRIPTION
# Stravalib Release Pull Request Template

Please use this template when you are preparing to make a release to stravalib

* [An overview of our release workflow can be found in our documentation.](https://stravalib.readthedocs.io/en/latest/contributing/build-release-guide.html)
* [Before making a release be sure to check out test PyPI](https://test.pypi.org/project/stravalib/) to ensure that the build is working properly.

## Release checklist
- [x] Be sure to clearly specify what version you are bumping to in the PR title: Example: Bump to version x.x
- [x] Add the version of this release to our changelog
- [x] Organize items changes under the new version in groups as follows: Added, Fixed and Changed
- [x] Add all contributors to the release below those sections
- [x] Wait for a maintainer to approve the pull request. Then merge! You are now ready to create the release.


Once this PR is merged you are ready to

- [ ] Create a tagged release on GitHub using the same version that you merged in the changelog added here
- [ ] When you publish that release, the GitHub action to push to PyPI will be invoked.

## Build and smoke test of this release content

`nox -s build` on `main` at `76a9018` produced `stravalib-2.5.0.post15`, and
`twine check` passed on both the wheel and the sdist. That is the same gate
`publish-pypi.yml` runs.

A fresh virtual environment held only that wheel. It ran read-only calls
against the real Strava API. 20 checks, 20 pass. The wire capture:

```
POST   /oauth/token               200  auth=None   query=[]  body=['client_id', 'client_secret', 'code', 'grant_type']           content-type=application/x-www-form-urlencoded
POST   /oauth/token               200  auth=None   query=[]  body=['client_id', 'client_secret', 'grant_type', 'refresh_token']   content-type=application/x-www-form-urlencoded
GET    /api/v3/athlete            200  auth=Bearer query=[]  body=[]
GET    /api/v3/athlete/activities 200  auth=Bearer query=['page', 'per_page']  body=[]
GET    /api/v3/athlete/clubs      200  auth=Bearer query=['page', 'per_page']  body=[]
GET    /api/v3/segments/explore   200  auth=Bearer query=['bounds']  body=[]
GET    /api/v3/activities/1       404  auth=Bearer query=['include_all_efforts']  body=[]
GET    /api/v3/push_subscriptions 200  auth=None   query=['client_id', 'client_secret', 'page', 'per_page']  body=[]
```

The log at INFO carried no secret value:

```
POST 'https://www.strava.com/oauth/token' with params ['client_id', 'client_secret', 'code', 'grant_type']
```

This covers #740 (form body, empty query, names in the log), #733 and #734
(Bearer header, no token in a URL, no `Authorization` on `/oauth/token`), #736
(both warnings and the bounds message), the automatic refresh of an expired
token, and a 404 raising `ObjectNotFound`.

Not covered: `create_subscription` and `delete_subscription` write server-side
state, so the read-only limit excludes them. They use the same
`_request(..., data=...)` plumbing that the token calls above exercised.
`ApplicationInactive` (#730) cannot be triggered against an active
application; the unit tests in `test_protocol_errors.py` cover it.
